### PR TITLE
Improve PlayerProfile UI consistency and readability

### DIFF
--- a/src/components/BallRunDistribution.jsx
+++ b/src/components/BallRunDistribution.jsx
@@ -114,14 +114,14 @@ const BallRunDistribution = ({ innings, isMobile: isMobileProp }) => {
   return (
     <Card isMobile={isMobile}>
       <Typography variant={isMobile ? "h6" : "h5"} sx={{ fontWeight: 600, mb: 2 }}>
-        Innings Balls Faced vs Runs Distribution
+        Inning Distribution
       </Typography>
       <Box sx={{ width: '100%', height: chartHeight }}>
         <ResponsiveContainer>
           <BarChart
             data={data}
             layout="vertical"
-            margin={{ top: 20, right: isMobile ? 5 : 20, left: isMobile ? 10 : 40, bottom: isMobile ? 15 : 30 }}
+            margin={{ top: 20, right: isMobile ? 5 : 20, left: isMobile ? 20 : 60, bottom: isMobile ? 25 : 40 }}
           >
             <CartesianGrid strokeDasharray="3 3" />
             <XAxis
@@ -131,7 +131,7 @@ const BallRunDistribution = ({ innings, isMobile: isMobileProp }) => {
               <Label
                 value="Number of Innings"
                 position="bottom"
-                offset={10}
+                offset={isMobile ? 5 : 0}
                 style={{ fontSize: isMobile ? 11 : 12 }}
               />
             </XAxis>
@@ -141,10 +141,10 @@ const BallRunDistribution = ({ innings, isMobile: isMobileProp }) => {
               tick={{ fontSize: isMobile ? 10 : 12 }}
             >
               <Label
-                value="Balls"
+                value="Balls Faced"
                 angle={-90}
                 position="insideLeft"
-                offset={-10}
+                offset={isMobile ? 5 : 15}
                 style={{ textAnchor: 'middle', fontSize: isMobile ? 11 : 12 }}
               />
             </YAxis>

--- a/src/components/CareerStatsCards.jsx
+++ b/src/components/CareerStatsCards.jsx
@@ -72,9 +72,9 @@ const CareerStatsCards = ({ stats, isMobile = false }) => {
         xs: '1fr',
         sm: '1fr 1fr',
         md: '1fr 1fr 1fr',
-        lg: 'repeat(6, 1fr)'
+        lg: 'repeat(3, 1fr)'
       },
-      mb: 4
+      mb: 3
     }}>
       <StatCard
         label="MATCHES"

--- a/src/components/ContributionGraph.jsx
+++ b/src/components/ContributionGraph.jsx
@@ -113,16 +113,16 @@ const ContributionGraph = ({ innings, playerName }) => {
       marginBottom: '20px'
     }}>
       <div style={{ marginBottom: '8px' }}>
-        <span style={{ fontWeight: 600, fontSize: '14px' }}>Performance Graph</span>
-        <span style={{ color: '#666', fontSize: '12px', marginLeft: '12px' }}>
-          {stats.total} innings
-        </span>
-        <span style={{ color: '#666', fontSize: '12px', marginLeft: '12px' }}>
-          Avg Fantasy: {stats.avgFantasy.toFixed(1)} pts
-        </span>
-        <span style={{ color: '#666', fontSize: '12px', marginLeft: '12px' }}>
-          🦆 {stats.ducks} ducks
-        </span>
+        <div style={{ fontWeight: 600, fontSize: '14px', marginBottom: '4px' }}>Performance Graph</div>
+        <div style={{ color: '#666', fontSize: '12px' }}>
+          <span>{stats.total} innings</span>
+          <span style={{ marginLeft: '12px' }}>
+            Avg Fantasy: {stats.avgFantasy.toFixed(1)} pts
+          </span>
+          <span style={{ marginLeft: '12px' }}>
+            🦆 {stats.ducks} ducks
+          </span>
+        </div>
       </div>
       
       <div style={{ overflowX: 'auto' }}>

--- a/src/components/InningsScatter.jsx
+++ b/src/components/InningsScatter.jsx
@@ -129,7 +129,7 @@ const InningsScatter = ({ innings }) => {
   return (
     <Card isMobile={isMobile}>
       <Typography variant={isMobile ? "h6" : "h5"} sx={{ fontWeight: 600, mb: 2 }}>
-        Innings Distribution
+        Balls Faced vs Runs
       </Typography>
 
       <Box sx={{ mb: isMobile ? 2 : 3 }}>
@@ -146,15 +146,15 @@ const InningsScatter = ({ innings }) => {
           <ScatterChart margin={{
             top: 10,
             right: isMobile ? 5 : 20,
-            bottom: isMobile ? 25 : 40,
-            left: isMobile ? 5 : 40
+            bottom: isMobile ? 30 : 45,
+            left: isMobile ? 10 : 50
           }}>
             <CartesianGrid strokeDasharray="3 3" />
             <XAxis
               {...getAxisProps(xMetric)}
               dataKey={xAxisMetrics[xMetric].key}
               name={xAxisMetrics[xMetric].label}
-              label={isMobile ? undefined : { value: xAxisMetrics[xMetric].label, position: 'bottom' }}
+              label={isMobile ? undefined : { value: xAxisMetrics[xMetric].label, position: 'bottom', offset: 0 }}
               tick={{ fontSize: isMobile ? 9 : 12 }}
             />
             <YAxis
@@ -164,7 +164,8 @@ const InningsScatter = ({ innings }) => {
               label={isMobile ? undefined : {
                 value: yAxisMetrics[yMetric].label,
                 angle: -90,
-                position: 'left'
+                position: 'insideLeft',
+                offset: 10
               }}
               tick={{ fontSize: isMobile ? 9 : 12 }}
             />

--- a/src/components/PaceSpinBreakdown.jsx
+++ b/src/components/PaceSpinBreakdown.jsx
@@ -94,21 +94,23 @@ const PaceSpinBreakdown = ({ stats, isMobile: isMobileProp }) => {
     <Card isMobile={isMobile}>
       <Box sx={{
         display: 'flex',
-        flexDirection: isMobile ? 'column' : 'row',
         justifyContent: 'space-between',
-        alignItems: isMobile ? 'flex-start' : 'center',
+        alignItems: 'center',
         mb: 2,
-        gap: isMobile ? 1.5 : 0
+        gap: 1,
+        flexWrap: isMobile ? 'wrap' : 'nowrap'
       }}>
-        <Typography variant={isMobile ? "h6" : "h5"} sx={{ fontWeight: 600 }}>
-          Pace vs Spin Analysis
+        <Typography variant={isMobile ? "h6" : "h5"} sx={{ fontWeight: 600, flexShrink: 0 }}>
+          Pace vs Spin
         </Typography>
-        <FilterBar
-          filters={filterConfig}
-          activeFilters={{ metric: selectedMetric }}
-          onFilterChange={handleFilterChange}
-          isMobile={isMobile}
-        />
+        <Box sx={{ flexShrink: 1, minWidth: 0 }}>
+          <FilterBar
+            filters={filterConfig}
+            activeFilters={{ metric: selectedMetric }}
+            onFilterChange={handleFilterChange}
+            isMobile={isMobile}
+          />
+        </Box>
       </Box>
 
       <Box sx={{ width: '100%', height: chartHeight, mt: 2 }}>
@@ -128,22 +130,12 @@ const PaceSpinBreakdown = ({ stats, isMobile: isMobileProp }) => {
             <YAxis type="category" dataKey="phase" axisLine={false} tick={{ fontSize: isMobile ? 10 : 12 }} />
             <Tooltip content={<CustomTooltip />} />
             <Legend wrapperStyle={{ fontSize: isMobile ? '0.75rem' : '0.875rem' }} />
-            <Bar dataKey="pace" name="vs Pace" fill={designColors.primary[500]} barSize={20} />
-            <Bar dataKey="spin" name="vs Spin" fill={designColors.chart[2]} barSize={20} />
-            <Bar dataKey="overall" name="Overall" fill={designColors.chart[5]} barSize={20} />
+            <Bar dataKey="pace" name="vs Pace" fill={designColors.chart.blue} barSize={20} />
+            <Bar dataKey="spin" name="vs Spin" fill={designColors.chart.orange} barSize={20} />
+            <Bar dataKey="overall" name="Overall" fill={designColors.chart.green} barSize={20} />
           </BarChart>
         </ResponsiveContainer>
       </Box>
-
-      <Typography variant="caption" color="text.secondary" sx={{ display: 'block', textAlign: 'center', mt: 2, fontSize: isMobile ? '0.7rem' : undefined }}>
-        {selectedMetric === 'strike_rate'
-          ? 'Higher values indicate faster scoring'
-          : selectedMetric === 'average'
-          ? 'Higher values indicate better consistency'
-          : selectedMetric === 'boundary_percentage'
-          ? 'Higher values indicate more boundaries'
-          : 'Higher values indicate more dot balls'}
-      </Typography>
     </Card>
   );
 };

--- a/src/components/PhasePerformanceRadar.jsx
+++ b/src/components/PhasePerformanceRadar.jsx
@@ -1,8 +1,6 @@
 import React, { useState } from 'react';
 import {
   Typography,
-  ButtonGroup,
-  Button,
   Box,
   useMediaQuery,
   useTheme
@@ -52,10 +50,10 @@ const PhasePerformanceRadar = ({ stats, isMobile: isMobileProp }) => {
 
   const metrics = ['Strike Rate', 'Average', 'Boundary %', 'Dot %'];
   const colors = {
-    'Strike Rate': designColors.chart[0],
-    'Average': designColors.chart[2],
-    'Boundary %': designColors.chart[4],
-    'Dot %': designColors.chart[6]
+    'Strike Rate': designColors.chart.blue,
+    'Average': designColors.chart.green,
+    'Boundary %': designColors.chart.orange,
+    'Dot %': designColors.chart.purple
   };
 
   // Responsive height calculation - fits in mobile viewport for screenshots
@@ -83,44 +81,23 @@ const PhasePerformanceRadar = ({ stats, isMobile: isMobileProp }) => {
     <Card isMobile={isMobile}>
       <Box sx={{
         display: 'flex',
-        flexDirection: isMobile ? 'column' : 'row',
         justifyContent: 'space-between',
-        alignItems: isMobile ? 'flex-start' : 'center',
+        alignItems: 'center',
         mb: 2,
-        gap: isMobile ? 1.5 : 0
+        gap: 1,
+        flexWrap: isMobile ? 'wrap' : 'nowrap'
       }}>
-        <Typography variant={isMobile ? "h6" : "h5"} sx={{ fontWeight: 600 }}>
-          Phase-wise Performance
+        <Typography variant={isMobile ? "h6" : "h5"} sx={{ fontWeight: 600, flexShrink: 0 }}>
+          Phase Radar
         </Typography>
-        {isMobile ? (
+        <Box sx={{ flexShrink: 1, minWidth: 0 }}>
           <FilterBar
             filters={filterConfig}
             activeFilters={{ view: selectedView }}
             onFilterChange={handleFilterChange}
             isMobile={isMobile}
           />
-        ) : (
-          <ButtonGroup variant="outlined" size="small">
-            <Button
-              onClick={() => setSelectedView('overall')}
-              variant={selectedView === 'overall' ? 'contained' : 'outlined'}
-            >
-              Overall
-            </Button>
-            <Button
-              onClick={() => setSelectedView('pace')}
-              variant={selectedView === 'pace' ? 'contained' : 'outlined'}
-            >
-              vs Pace
-            </Button>
-            <Button
-              onClick={() => setSelectedView('spin')}
-              variant={selectedView === 'spin' ? 'contained' : 'outlined'}
-            >
-              vs Spin
-            </Button>
-          </ButtonGroup>
-        )}
+        </Box>
       </Box>
 
       <Box sx={{ width: '100%', height: chartHeight }}>

--- a/src/components/PitchMap/PitchMapVisualization.jsx
+++ b/src/components/PitchMap/PitchMapVisualization.jsx
@@ -33,7 +33,8 @@ const PitchMapVisualization = ({
   subtitle,
   width: propWidth,
   svgRef,
-  hideStumps = false
+  hideStumps = false,
+  hideLegend = false
 }) => {
   // Use ref to measure container if no width prop
   const [containerWidth, setContainerWidth] = React.useState(propWidth || PITCH_DIMENSIONS.width);
@@ -194,13 +195,15 @@ const PitchMapVisualization = ({
         {/* Axis labels */}
         <AxisLabels dimensions={scaledDimensions} mode={mode} scale={scale} />
       </svg>
-      
+
       {/* Legend */}
-      <ColorLegend 
-        metric={colorMetric} 
-        dataRange={dataRange}
-        width={scaledDimensions.pitchWidth}
-      />
+      {!hideLegend && (
+        <ColorLegend
+          metric={colorMetric}
+          dataRange={dataRange}
+          width={scaledDimensions.pitchWidth}
+        />
+      )}
     </Box>
   );
 };

--- a/src/components/PlayerPitchMap.jsx
+++ b/src/components/PlayerPitchMap.jsx
@@ -246,6 +246,7 @@ const PlayerPitchMap = ({
           title={playerName}
           subtitle={`${phase === 'overall' ? 'All Phases' : phase} ${bowlKind !== 'all' ? `• ${bowlKind}` : ''}`}
           hideStumps={true}
+          hideLegend={true}
         />
       </Box>
     </Card>

--- a/src/components/PlayerProfile.jsx
+++ b/src/components/PlayerProfile.jsx
@@ -366,18 +366,6 @@ const PlayerProfile = () => {
               isMobile={isMobile}
             />
 
-            {/* Contextual Query Prompts */}
-            <ContextualQueryPrompts
-              queries={getBatterContextualQueries(selectedPlayer, {
-                startDate: dateRange.start,
-                endDate: dateRange.end,
-                leagues: competitionFilters.leagues,
-                venue: selectedVenue !== 'All Venues' ? selectedVenue : null,
-              })}
-              title={`🔍 Explore ${selectedPlayer.split(' ').pop()}'s Data`}
-              isMobile={isMobile}
-            />
-
             <Box sx={{ mt: isMobile ? 2 : 3 }}>
               <ContributionGraph
                 innings={stats.innings || []}
@@ -427,6 +415,18 @@ const PlayerProfile = () => {
             </Box>
             <TopInnings innings={stats.innings} count={10} isMobile={isMobile} />
             <BowlingMatchupMatrix stats={stats} isMobile={isMobile} />
+
+            {/* Contextual Query Prompts */}
+            <ContextualQueryPrompts
+              queries={getBatterContextualQueries(selectedPlayer, {
+                startDate: dateRange.start,
+                endDate: dateRange.end,
+                leagues: competitionFilters.leagues,
+                venue: selectedVenue !== 'All Venues' ? selectedVenue : null,
+              })}
+              title={`🔍 Explore ${selectedPlayer.split(' ').pop()}'s Data`}
+              isMobile={isMobile}
+            />
           </Box>
         )}
       </Box>

--- a/src/components/StrikeRateIntervals.jsx
+++ b/src/components/StrikeRateIntervals.jsx
@@ -98,21 +98,23 @@ const StrikeRateIntervals = ({ ballStats = [], isMobile: isMobileProp }) => {  /
     <Card isMobile={isMobile}>
       <Box sx={{
         display: 'flex',
-        flexDirection: isMobile ? 'column' : 'row',
         justifyContent: 'space-between',
-        alignItems: isMobile ? 'flex-start' : 'center',
+        alignItems: 'center',
         mb: 2,
-        gap: isMobile ? 1.5 : 0
+        gap: 1,
+        flexWrap: isMobile ? 'wrap' : 'nowrap'
       }}>
-        <Typography variant={isMobile ? "h6" : "h5"} sx={{ fontWeight: 600 }}>
-          Strike Rate Progression by Intervals
+        <Typography variant={isMobile ? "h6" : "h5"} sx={{ fontWeight: 600, flexShrink: 0 }}>
+          SR Progression
         </Typography>
-        <FilterBar
-          filters={filterConfig}
-          activeFilters={{ interval }}
-          onFilterChange={handleFilterChange}
-          isMobile={isMobile}
-        />
+        <Box sx={{ flexShrink: 1, minWidth: 0 }}>
+          <FilterBar
+            filters={filterConfig}
+            activeFilters={{ interval }}
+            onFilterChange={handleFilterChange}
+            isMobile={isMobile}
+          />
+        </Box>
       </Box>
       <Box sx={{ width: '100%', height: chartHeight }}>
         <ResponsiveContainer>
@@ -160,19 +162,19 @@ const StrikeRateIntervals = ({ ballStats = [], isMobile: isMobileProp }) => {  /
               yAxisId="left"
               dataKey="strikeRate"
               name="Strike Rate"
-              fill={designColors.primary[500]}
+              fill={designColors.chart.blue}
             />
             <Bar
               yAxisId="right"
               dataKey="boundaryPercentage"
               name="Boundary %"
-              fill={designColors.chart[2]}
+              fill={designColors.chart.green}
             />
             <Bar
               yAxisId="right"
               dataKey="dotPercentage"
               name="Dot %"
-              fill={designColors.chart[4]}
+              fill={designColors.chart.orange}
             />
           </BarChart>
         </ResponsiveContainer>

--- a/src/components/StrikeRateProgression.jsx
+++ b/src/components/StrikeRateProgression.jsx
@@ -52,17 +52,14 @@ const StrikeRateProgression = ({ selectedPlayer, dateRange, selectedVenue, compe
 
   return (
     <Card isMobile={isMobile}>
-      <Typography variant={isMobile ? "h6" : "h5"} sx={{ fontWeight: 600, mb: 1 }}>
-        Ball-by-Ball Strike Rate Progression
-      </Typography>
-      <Typography variant="body2" color="text.secondary" sx={{ mb: 2, fontSize: isMobile ? '0.75rem' : undefined }}>
-        Strike rate evolution through innings
+      <Typography variant={isMobile ? "h6" : "h5"} sx={{ fontWeight: 600, mb: 2 }}>
+        nth Ball SR
       </Typography>
       <Box sx={{ height: chartHeight, width: '100%' }}>
         <ResponsiveContainer>
           <LineChart
             data={data}
-            margin={{ top: 20, right: isMobile ? 5 : 30, bottom: isMobile ? 25 : 40, left: isMobile ? 5 : 40 }}
+            margin={{ top: 20, right: isMobile ? 10 : 40, bottom: isMobile ? 15 : 30, left: isMobile ? 10 : 50 }}
           >
             <CartesianGrid strokeDasharray="3 3" />
             <XAxis
@@ -99,8 +96,8 @@ const StrikeRateProgression = ({ selectedPlayer, dateRange, selectedVenue, compe
               verticalAlign="bottom"
               height={36}
               wrapperStyle={{
-                paddingTop: '20px',
-                paddingBottom: '10px',
+                paddingTop: '10px',
+                paddingBottom: '0px',
                 display: 'flex',
                 justifyContent: 'center',
                 gap: isMobile ? '20px' : '50px',
@@ -110,7 +107,7 @@ const StrikeRateProgression = ({ selectedPlayer, dateRange, selectedVenue, compe
             <Line
               type="monotone"
               dataKey="strike_rate"
-              stroke={designColors.primary[500]}
+              stroke={designColors.chart.blue}
               name="Strike Rate"
               yAxisId="left"
               dot={false}
@@ -118,7 +115,7 @@ const StrikeRateProgression = ({ selectedPlayer, dateRange, selectedVenue, compe
             <Line
               type="monotone"
               dataKey="innings_with_n_balls"
-              stroke={designColors.chart[2]}
+              stroke={designColors.chart.orange}
               name="Innings Count"
               yAxisId="right"
               dot={false}

--- a/src/components/TopInnings.jsx
+++ b/src/components/TopInnings.jsx
@@ -7,8 +7,6 @@ import {
   TableHead,
   TableRow,
   Typography,
-  ToggleButtonGroup,
-  ToggleButton,
   Box
 } from '@mui/material';
 import Card from './ui/Card';
@@ -77,37 +75,23 @@ const TopInnings = ({ innings, count = 10, isMobile = false }) => {
     <Card isMobile={isMobile}>
       <Box sx={{
         display: 'flex',
-        flexDirection: isMobile ? 'column' : 'row',
         justifyContent: 'space-between',
-        alignItems: isMobile ? 'flex-start' : 'center',
+        alignItems: 'center',
         mb: isMobile ? 1.5 : 3,
-        gap: isMobile ? 1.5 : 0
+        gap: 1,
+        flexWrap: isMobile ? 'wrap' : 'nowrap'
       }}>
-        <Typography variant={isMobile ? "h6" : "h5"} sx={{ fontWeight: 600 }}>
-          {viewMode === 'topScoring' ? 'Top Scoring Innings' : 'Recent Form'}
+        <Typography variant={isMobile ? "h6" : "h5"} sx={{ fontWeight: 600, flexShrink: 0 }}>
+          {viewMode === 'topScoring' ? 'Top Innings' : 'Recent Form'}
         </Typography>
-        {isMobile ? (
+        <Box sx={{ flexShrink: 1, minWidth: 0 }}>
           <FilterBar
             filters={filterConfig}
             activeFilters={{ view: viewMode }}
             onFilterChange={handleFilterChange}
             isMobile={isMobile}
           />
-        ) : (
-          <ToggleButtonGroup
-            value={viewMode}
-            exclusive
-            onChange={handleViewChange}
-            size="small"
-          >
-            <ToggleButton value="topScoring">
-              Top Scoring
-            </ToggleButton>
-            <ToggleButton value="recentForm">
-              Recent Form
-            </ToggleButton>
-          </ToggleButtonGroup>
-        )}
+        </Box>
       </Box>
 
       <TableContainer>

--- a/src/components/WagonWheel.jsx
+++ b/src/components/WagonWheel.jsx
@@ -156,14 +156,14 @@ const WagonWheel = ({
   const renderWagonWheel = () => {
     if (!wagonData || !stats) return null;
 
-    // Responsive dimensions - reduce radius to fit within card, allow oval shape for cricket field
+    // Responsive dimensions - vertical oval for cricket field
     const containerWidth = typeof window !== 'undefined' ? Math.min(window.innerWidth - (isMobile ? 48 : 80), 400) : 400;
     const width = containerWidth;
-    const height = containerWidth * (isMobile ? 1.0 : 1.05); // Slightly oval on mobile, more circular on desktop
+    const height = containerWidth * 1.3; // Vertical oval - taller than wide
     const centerX = width / 2;
     const centerY = height / 2;
-    const maxRadiusX = width * 0.40; // Reduced from 0.425 to fit better
-    const maxRadiusY = height * 0.38; // Oval shape
+    const maxRadiusX = width * 0.38; // Narrower width for vertical oval
+    const maxRadiusY = height * 0.42; // Taller height for vertical oval
     const batterRadius = width * 0.02; // 2% of width (8/400)
 
     // Field zones (8 zones + center)


### PR DESCRIPTION
- Update CareerStatsCards to 3 cards per row for reduced vertical space
- Move Explore data card to end of page after all components
- Restructure Performance Graph with title on first line, stats on second
- Convert Wagon Wheel to vertical oval field orientation
- Remove legend from Pitch Map visualization
- Standardize Phase Radar with one-line title/filters layout and contrasty colors
- Standardize Pace vs Spin with one-line layout, updated colors, removed tip
- Improve Inning Distribution with better axes labels and title
- Shorten nth Ball SR title, improve colors and reduce padding
- Update Balls Faced vs Runs title and position axes labels closer
- Standardize SR Progression components with consistent layouts and colors
- Optimize Top Innings title for better space utilization

All chart components now use consistent FilterBar positioning and
improved color schemes from design system for better readability.