### PR TITLE
Refine PlayerProfile layout and spacing

### DIFF
--- a/src/components/CareerStatsCards.jsx
+++ b/src/components/CareerStatsCards.jsx
@@ -1,124 +1,87 @@
 import React from 'react';
-import { Box } from '@mui/material';
-import {
-  EmojiEvents as TrophyIcon,
-  PercentOutlined as PercentIcon,
-  Timer as TimerIcon,
-  TrendingUp as TrendingUpIcon,
-  GpsFixed as TargetIcon,
-  Bolt as FlashIcon
-} from '@mui/icons-material';
-import StatCard from './ui/StatCard';
+import { Box, Typography } from '@mui/material';
+import Card from './ui/Card';
 
 const CareerStatsCards = ({ stats, isMobile = false }) => {
   const { overall } = stats;
-
-  if (isMobile) {
-    return (
-      <Box sx={{
-        display: 'grid',
-        gridTemplateColumns: 'repeat(2, 1fr)',
-        gap: 2,
-        mb: 3
-      }}>
-        <StatCard
-          label="MATCHES"
-          value={overall.matches}
-          icon={TrophyIcon}
-          variant="primary"
-          isMobile={isMobile}
-        />
-        <StatCard
-          label="RUNS"
-          value={overall.runs}
-          subtitle={`Avg: ${overall.average.toFixed(2)}`}
-          icon={TrendingUpIcon}
-          variant="primary"
-          isMobile={isMobile}
-        />
-        <StatCard
-          label="STRIKE RATE"
-          value={overall.strike_rate.toFixed(1)}
-          icon={TimerIcon}
-          isMobile={isMobile}
-        />
-        <StatCard
-          label="50s/100s"
-          value={`${overall.fifties}/${overall.hundreds}`}
-          icon={TargetIcon}
-          isMobile={isMobile}
-        />
-        <StatCard
-          label="DOT %"
-          value={`${overall.dot_percentage.toFixed(1)}%`}
-          icon={PercentIcon}
-          isMobile={isMobile}
-        />
-        <StatCard
-          label="BOUNDARY %"
-          value={`${overall.boundary_percentage.toFixed(1)}%`}
-          icon={FlashIcon}
-          isMobile={isMobile}
-        />
-      </Box>
-    );
-  }
 
   return (
     <Box sx={{
       display: 'grid',
       gap: 2,
-      gridTemplateColumns: {
-        xs: '1fr',
-        sm: '1fr 1fr',
-        md: '1fr 1fr 1fr',
-        lg: 'repeat(3, 1fr)'
-      },
+      gridTemplateColumns: '1fr',
       mb: 3
     }}>
-      <StatCard
-        label="MATCHES"
-        value={overall.matches}
-        subtitle="Total Innings"
-        icon={TrophyIcon}
-        variant="primary"
-        isMobile={isMobile}
-      />
-      <StatCard
-        label="RUNS"
-        value={overall.runs}
-        subtitle={`Avg: ${overall.average.toFixed(2)}`}
-        icon={TrendingUpIcon}
-        variant="primary"
-        isMobile={isMobile}
-      />
-      <StatCard
-        label="STRIKE RATE"
-        value={overall.strike_rate.toFixed(1)}
-        icon={TimerIcon}
-        isMobile={isMobile}
-      />
-      <StatCard
-        label="50s/100s"
-        value={`${overall.fifties}/${overall.hundreds}`}
-        subtitle={`${overall.fifties + overall.hundreds} milestone innings`}
-        icon={TargetIcon}
-        isMobile={isMobile}
-      />
-      <StatCard
-        label="DOT %"
-        value={`${overall.dot_percentage.toFixed(1)}%`}
-        subtitle="Dot ball percentage"
-        icon={PercentIcon}
-        isMobile={isMobile}
-      />
-      <StatCard
-        label="BOUNDARY %"
-        value={`${overall.boundary_percentage.toFixed(1)}%`}
-        subtitle="Boundary percentage"
-        icon={FlashIcon}
-        isMobile={isMobile}
-      />
+      {/* Primary Stats Card */}
+      <Card isMobile={isMobile}>
+        <Box sx={{
+          display: 'grid',
+          gridTemplateColumns: { xs: 'repeat(2, 1fr)', md: 'repeat(4, 1fr)' },
+          gap: { xs: 2, md: 3 }
+        }}>
+          <Box>
+            <Typography variant="caption" color="text.secondary" sx={{ fontSize: isMobile ? '0.7rem' : '0.75rem', fontWeight: 600 }}>
+              MATCHES
+            </Typography>
+            <Typography variant={isMobile ? "h5" : "h4"} sx={{ fontWeight: 700, mt: 0.5 }}>
+              {overall.matches}
+            </Typography>
+          </Box>
+          <Box>
+            <Typography variant="caption" color="text.secondary" sx={{ fontSize: isMobile ? '0.7rem' : '0.75rem', fontWeight: 600 }}>
+              RUNS
+            </Typography>
+            <Typography variant={isMobile ? "h5" : "h4"} sx={{ fontWeight: 700, mt: 0.5 }}>
+              {overall.runs}
+            </Typography>
+            <Typography variant="caption" color="text.secondary" sx={{ fontSize: isMobile ? '0.65rem' : '0.7rem' }}>
+              Avg: {overall.average.toFixed(2)}
+            </Typography>
+          </Box>
+          <Box>
+            <Typography variant="caption" color="text.secondary" sx={{ fontSize: isMobile ? '0.7rem' : '0.75rem', fontWeight: 600 }}>
+              STRIKE RATE
+            </Typography>
+            <Typography variant={isMobile ? "h5" : "h4"} sx={{ fontWeight: 700, mt: 0.5 }}>
+              {overall.strike_rate.toFixed(1)}
+            </Typography>
+          </Box>
+          <Box>
+            <Typography variant="caption" color="text.secondary" sx={{ fontSize: isMobile ? '0.7rem' : '0.75rem', fontWeight: 600 }}>
+              50s/100s
+            </Typography>
+            <Typography variant={isMobile ? "h5" : "h4"} sx={{ fontWeight: 700, mt: 0.5 }}>
+              {overall.fifties}/{overall.hundreds}
+            </Typography>
+          </Box>
+        </Box>
+      </Card>
+
+      {/* Secondary Stats Card */}
+      <Card isMobile={isMobile}>
+        <Box sx={{
+          display: 'grid',
+          gridTemplateColumns: { xs: 'repeat(2, 1fr)', md: 'repeat(2, 1fr)' },
+          gap: { xs: 2, md: 3 }
+        }}>
+          <Box>
+            <Typography variant="caption" color="text.secondary" sx={{ fontSize: isMobile ? '0.7rem' : '0.75rem', fontWeight: 600 }}>
+              DOT %
+            </Typography>
+            <Typography variant={isMobile ? "h5" : "h4"} sx={{ fontWeight: 700, mt: 0.5 }}>
+              {overall.dot_percentage.toFixed(1)}%
+            </Typography>
+          </Box>
+          <Box>
+            <Typography variant="caption" color="text.secondary" sx={{ fontSize: isMobile ? '0.7rem' : '0.75rem', fontWeight: 600 }}>
+              BOUNDARY %
+            </Typography>
+            <Typography variant={isMobile ? "h5" : "h4"} sx={{ fontWeight: 700, mt: 0.5 }}>
+              {overall.boundary_percentage.toFixed(1)}%
+            </Typography>
+          </Box>
+        </Box>
+      </Card>
     </Box>
   );
 };

--- a/src/components/PitchMap/pitchMapConstants.js
+++ b/src/components/PitchMap/pitchMapConstants.js
@@ -61,8 +61,8 @@ export const LENGTH_SHORT_LABELS = {
 // SVG dimensions and layout - mobile-first
 export const PITCH_DIMENSIONS = {
   width: 360,
-  height: 580,
-  padding: { top: 70, right: 55, bottom: 60, left: 20 },
+  height: 520,
+  padding: { top: 50, right: 45, bottom: 40, left: 15 },
   pitchWidth: 280,
   pitchHeight: 420,
   stumpHeight: 40,

--- a/src/components/WagonWheel.jsx
+++ b/src/components/WagonWheel.jsx
@@ -156,22 +156,21 @@ const WagonWheel = ({
   const renderWagonWheel = () => {
     if (!wagonData || !stats) return null;
 
-    // Responsive dimensions - vertical oval for cricket field
+    // Responsive dimensions - circular field
     const containerWidth = typeof window !== 'undefined' ? Math.min(window.innerWidth - (isMobile ? 48 : 80), 400) : 400;
     const width = containerWidth;
-    const height = containerWidth * 1.3; // Vertical oval - taller than wide
+    const height = containerWidth; // Circular - same width and height
     const centerX = width / 2;
     const centerY = height / 2;
-    const maxRadiusX = width * 0.38; // Narrower width for vertical oval
-    const maxRadiusY = height * 0.42; // Taller height for vertical oval
+    const maxRadius = width * 0.45; // Single radius for circle
     const batterRadius = width * 0.02; // 2% of width (8/400)
 
     // Field zones (8 zones + center)
     const zoneLines = [];
     for (let i = 0; i < 8; i++) {
       const angle = (i * Math.PI / 4) - (Math.PI / 2); // Start from top
-      const x2 = centerX + maxRadiusX * Math.cos(angle);
-      const y2 = centerY + maxRadiusY * Math.sin(angle);
+      const x2 = centerX + maxRadius * Math.cos(angle);
+      const y2 = centerY + maxRadius * Math.sin(angle);
       zoneLines.push(
         <line
           key={`zone-${i}`}
@@ -191,21 +190,20 @@ const WagonWheel = ({
       .filter(d => d.wagon_x !== null && d.wagon_y !== null)
       .map((delivery, idx) => {
         // Scale coordinates to fit in our SVG (assuming wagon_x/y are in range 0-300)
-        const scaleX = maxRadiusX / 300;
-        const scaleY = maxRadiusY / 300;
-        let x = centerX + (delivery.wagon_x - 150) * scaleX;
-        let y = centerY + (delivery.wagon_y - 150) * scaleY;
+        const scale = maxRadius / 300;
+        let x = centerX + (delivery.wagon_x - 150) * scale;
+        let y = centerY + (delivery.wagon_y - 150) * scale;
 
-        // For boundaries (4s and 6s), extend to the ellipse edge
+        // For boundaries (4s and 6s), extend to the circle edge
         if (delivery.runs === 4 || delivery.runs === 6) {
           const dx = x - centerX;
           const dy = y - centerY;
           const distance = Math.sqrt(dx * dx + dy * dy);
           if (distance > 0) {
-            // Extend to ellipse boundary
+            // Extend to circle boundary
             const angle = Math.atan2(dy, dx);
-            x = centerX + maxRadiusX * Math.cos(angle);
-            y = centerY + maxRadiusY * Math.sin(angle);
+            x = centerX + maxRadius * Math.cos(angle);
+            y = centerY + maxRadius * Math.sin(angle);
           }
         }
 
@@ -244,12 +242,11 @@ const WagonWheel = ({
 
     return (
       <svg width={width} height={height} style={{ maxWidth: '100%', height: 'auto' }}>
-        {/* Field boundary - ellipse for cricket field */}
-        <ellipse
+        {/* Field boundary - circle for cricket field */}
+        <circle
           cx={centerX}
           cy={centerY}
-          rx={maxRadiusX}
-          ry={maxRadiusY}
+          r={maxRadius}
           fill="#f5f5f5"
           stroke="#bdbdbd"
           strokeWidth="2"
@@ -258,12 +255,11 @@ const WagonWheel = ({
         {/* Zone lines */}
         {zoneLines}
 
-        {/* Inner ellipse (30 yard circle) */}
-        <ellipse
+        {/* Inner circle (30 yard circle) */}
+        <circle
           cx={centerX}
           cy={centerY}
-          rx={maxRadiusX * 0.5}
-          ry={maxRadiusY * 0.5}
+          r={maxRadius * 0.5}
           fill="none"
           stroke="#e0e0e0"
           strokeWidth="1"
@@ -286,13 +282,6 @@ const WagonWheel = ({
 
         {/* Batter position (circle at center) */}
         <circle cx={centerX} cy={centerY} r={batterRadius} fill="#333" stroke="#000" strokeWidth="1" />
-
-        {/* Zone labels - Cricket orientation: batter faces down, bowler at bottom */}
-        {/* For right-handed batter: off side is LEFT (towards covers), leg side is RIGHT (towards square leg) */}
-        <text x={centerX} y={centerY + maxRadiusY + 20} textAnchor="middle" fontSize={Math.max(10, width * 0.028)} fill="#666" fontWeight="600">Straight</text>
-        <text x={centerX - maxRadiusX - 10} y={centerY + 5} textAnchor="end" fontSize={Math.max(10, width * 0.028)} fill="#666" fontWeight="600">Off</text>
-        <text x={centerX + maxRadiusX + 10} y={centerY + 5} textAnchor="start" fontSize={Math.max(10, width * 0.028)} fill="#666" fontWeight="600">Leg</text>
-        <text x={centerX} y={centerY - maxRadiusY - 10} textAnchor="middle" fontSize={Math.max(10, width * 0.028)} fill="#666" fontWeight="600">Behind</text>
       </svg>
     );
   };


### PR DESCRIPTION
CareerStatsCards:
- Redesign to 2 large cards instead of 6 small cards
- First card: Matches, Runs, Strike Rate, 50s/100s
- Second card: Dot %, Boundary %
- Cleaner layout with less vertical space

Wagon Wheel:
- Change from vertical oval to perfect circle
- Remove directional labels (Behind, Off, Leg, Straight)
- Better fit within card boundaries

Pitch Map:
- Reduce padding around pitch grid (top: 70→50, right: 55→45, bottom: 60→40, left: 20→15)
- Reduce overall height from 580 to 520
- Tighter visualization with less empty space