### PR TITLE
Add theme provider, central design system, and UI primitives

### DIFF
--- a/src/components/ui/LayoutGrid.jsx
+++ b/src/components/ui/LayoutGrid.jsx
@@ -1,0 +1,31 @@
+/**
+ * LayoutGrid Component - Consistent responsive grid layout
+ */
+import React from 'react';
+import { Box } from '@mui/material';
+import { spacing } from '../../theme/designSystem';
+
+const LayoutGrid = ({
+  children,
+  minColumnWidth = 280,
+  gap = spacing.lg,
+  sx = {},
+  ...props
+}) => {
+  return (
+    <Box
+      sx={{
+        display: 'grid',
+        gridTemplateColumns: `repeat(auto-fit, minmax(${minColumnWidth}px, 1fr))`,
+        gap: `${gap}px`,
+        width: '100%',
+        ...sx,
+      }}
+      {...props}
+    >
+      {children}
+    </Box>
+  );
+};
+
+export default LayoutGrid;

--- a/src/components/ui/index.js
+++ b/src/components/ui/index.js
@@ -1,0 +1,6 @@
+export { default as Card } from './Card';
+export { default as FilterBar } from './FilterBar';
+export { default as LayoutGrid } from './LayoutGrid';
+export { default as Section } from './Section';
+export { default as Skeleton } from './Skeleton';
+export { default as StatCard } from './StatCard';

--- a/src/index.css
+++ b/src/index.css
@@ -1,13 +1,22 @@
+:root {
+  --color-background: #fafafa;
+  --color-text-primary: #171717;
+  --color-text-secondary: #525252;
+  --font-sans: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue',
+    Arial, sans-serif;
+  --font-mono: 'SF Mono', Monaco, 'Cascadia Code', 'Roboto Mono', Consolas,
+    'Courier New', monospace;
+}
+
 body {
   margin: 0;
-  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen',
-    'Ubuntu', 'Cantarell', 'Fira Sans', 'Droid Sans', 'Helvetica Neue',
-    sans-serif;
+  font-family: var(--font-sans);
+  background-color: var(--color-background);
+  color: var(--color-text-primary);
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
 }
 
 code {
-  font-family: source-code-pro, Menlo, Monaco, Consolas, 'Courier New',
-    monospace;
+  font-family: var(--font-mono);
 }

--- a/src/index.js
+++ b/src/index.js
@@ -4,12 +4,17 @@ import './index.css';
 import App from './App';
 import reportWebVitals from './reportWebVitals';
 import { Analytics } from '@vercel/analytics/react';
+import { ThemeProvider, CssBaseline } from '@mui/material';
+import { theme } from './theme';
 
 const root = ReactDOM.createRoot(document.getElementById('root'));
 root.render(
   <React.StrictMode>
-    <App />
-    <Analytics />
+    <ThemeProvider theme={theme}>
+      <CssBaseline />
+      <App />
+      <Analytics />
+    </ThemeProvider>
   </React.StrictMode>
 );
 

--- a/src/theme/designSystem.js
+++ b/src/theme/designSystem.js
@@ -1,7 +1,11 @@
 /**
  * Design System - Cricket Data Thing
  *
- * World-class design tokens inspired by Stripe, Linear, and Vercel
+ * Single source of truth for design tokens and theme configuration.
+ * - Import tokens from this module instead of hardcoding values.
+ * - Use the MUI theme from src/theme for consistent component styling.
+ *
+ * World-class design tokens inspired by Stripe, Linear, and Vercel.
  */
 
 // Spacing scale (4px base unit)

--- a/src/theme/index.js
+++ b/src/theme/index.js
@@ -1,0 +1,9 @@
+import { createTheme } from '@mui/material/styles';
+import designSystem, { muiTheme } from './designSystem';
+
+const theme = createTheme(muiTheme);
+
+export { theme };
+export * from './designSystem';
+export default theme;
+export { designSystem };


### PR DESCRIPTION
### Motivation
- Establish a single source of truth for design tokens and MUI theme configuration so components consume consistent tokens.
- Wrap the application in a MUI `ThemeProvider` so Material components use the shared theme and baseline styles.
- Expose common UI building blocks to avoid ad-hoc `Box` styling across the codebase.
- Provide base CSS variables for background, text, and fonts to align global styles with the design tokens.

### Description
- Documented the design system header in `src/theme/designSystem.js` and added a `src/theme/index.js` entry that creates and exports the MUI `theme` and tokens.
- Wrapped the app in `ThemeProvider` and added `CssBaseline` in `src/index.js` to enable the shared theme across the app.
- Added global CSS variables and base font/background/text color rules in `src/index.css` to reflect token defaults.
- Added a new responsive `LayoutGrid` primitive at `src/components/ui/LayoutGrid.jsx` and a barrel export `src/components/ui/index.js` to expose `Card`, `FilterBar`, `LayoutGrid`, `Section`, `Skeleton`, and `StatCard`.

### Testing
- Started the development server with `npm start`, which launched and served the app successfully (compiled with ESLint warnings).
- Captured an automated Playwright screenshot of `http://127.0.0.1:3000` to verify the baseline theme was applied successfully.
- The dev server compilation completed with warnings but no runtime failures were encountered during the screenshot run.
- No unit tests were added or run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6959eee363ec832c8cdbab3886f70794)