### PR TITLE
Add Section & VisualizationCard and refactor PlayerProfile into sectioned layout

### DIFF
--- a/src/components/BallRunDistribution.jsx
+++ b/src/components/BallRunDistribution.jsx
@@ -14,10 +14,12 @@ import {
 import _ from 'lodash';
 import Card from './ui/Card';
 
-const BallRunDistribution = ({ innings, isMobile: isMobileProp }) => {
+const BallRunDistribution = ({ innings, isMobile: isMobileProp, wrapInCard = true }) => {
   const theme = useTheme();
   const isMobileDetected = useMediaQuery(theme.breakpoints.down('sm'));
   const isMobile = isMobileProp !== undefined ? isMobileProp : isMobileDetected;
+  const Wrapper = wrapInCard ? Card : Box;
+  const wrapperProps = wrapInCard ? { isMobile } : { sx: { width: '100%' } };
 
   const processData = () => {
     const ballRanges = {};
@@ -112,7 +114,7 @@ const BallRunDistribution = ({ innings, isMobile: isMobileProp }) => {
   const chartHeight = isMobile ? 350 : 400;
 
   return (
-    <Card isMobile={isMobile}>
+    <Wrapper {...wrapperProps}>
       <Typography variant={isMobile ? "h6" : "h5"} sx={{ fontWeight: 600, mb: 2 }}>
         Inning Distribution
       </Typography>
@@ -162,7 +164,7 @@ const BallRunDistribution = ({ innings, isMobile: isMobileProp }) => {
           </BarChart>
         </ResponsiveContainer>
       </Box>
-    </Card>
+    </Wrapper>
   );
 };
 

--- a/src/components/BowlingMatchupMatrix.jsx
+++ b/src/components/BowlingMatchupMatrix.jsx
@@ -41,10 +41,12 @@ const MetricCell = ({ stats, isMobile }) => {
   );
 };
 
-const BowlingMatchupMatrix = ({ stats, isMobile: isMobileProp }) => {
+const BowlingMatchupMatrix = ({ stats, isMobile: isMobileProp, wrapInCard = true }) => {
   const theme = useTheme();
   const isMobileDetected = useMediaQuery(theme.breakpoints.down('sm'));
   const isMobile = isMobileProp !== undefined ? isMobileProp : isMobileDetected;
+  const Wrapper = wrapInCard ? Card : Box;
+  const wrapperProps = wrapInCard ? { isMobile } : { sx: { width: '100%' } };
 
   // Dynamically get all bowling types from the stats data
   const bowlingTypes = stats?.phase_stats?.bowling_types
@@ -54,7 +56,7 @@ const BowlingMatchupMatrix = ({ stats, isMobile: isMobileProp }) => {
 
   if (!bowlingTypes.length) {
     return (
-      <Card isMobile={isMobile}>
+      <Wrapper {...wrapperProps}>
         <Box sx={{ display: 'flex', alignItems: 'center', mb: 2, gap: 1 }}>
           <Typography variant={isMobile ? "h6" : "h5"} sx={{ fontWeight: 600 }}>
             Bowling Type Matchups
@@ -66,12 +68,12 @@ const BowlingMatchupMatrix = ({ stats, isMobile: isMobileProp }) => {
         <Typography variant="body2" color="text.secondary">
           Bowling matchup data not available
         </Typography>
-      </Card>
+      </Wrapper>
     );
   }
 
   return (
-    <Card isMobile={isMobile}>
+    <Wrapper {...wrapperProps}>
       <Box sx={{ display: 'flex', alignItems: 'center', mb: 2, gap: 1 }}>
         <Typography variant={isMobile ? "h6" : "h5"} sx={{ fontWeight: 600 }}>
           Bowling Type Matchups
@@ -108,7 +110,7 @@ const BowlingMatchupMatrix = ({ stats, isMobile: isMobileProp }) => {
           </tbody>
         </table>
       </Box>
-    </Card>
+    </Wrapper>
   );
 };
 

--- a/src/components/InningsScatter.jsx
+++ b/src/components/InningsScatter.jsx
@@ -14,11 +14,13 @@ import Card from './ui/Card';
 import FilterBar from './ui/FilterBar';
 import { colors as designColors } from '../theme/designSystem';
 
-const InningsScatter = ({ innings }) => {
+const InningsScatter = ({ innings, wrapInCard = true }) => {
   const [xMetric, setXMetric] = useState('balls');
   const [yMetric, setYMetric] = useState('strike_rate');
   const theme = useTheme();
   const isMobile = useMediaQuery(theme.breakpoints.down('sm'));
+  const Wrapper = wrapInCard ? Card : Box;
+  const wrapperProps = wrapInCard ? { isMobile } : { sx: { width: '100%' } };
 
   const getPhase = (over) => {
     if (over < 6) return 0;
@@ -127,7 +129,7 @@ const InningsScatter = ({ innings }) => {
   };
 
   return (
-    <Card isMobile={isMobile}>
+    <Wrapper {...wrapperProps}>
       <Typography variant={isMobile ? "h6" : "h5"} sx={{ fontWeight: 600, mb: 2 }}>
         Balls Faced vs Runs
       </Typography>
@@ -182,7 +184,7 @@ const InningsScatter = ({ innings }) => {
           </ScatterChart>
         </ResponsiveContainer>
       </Box>
-    </Card>
+    </Wrapper>
   );
 };
 

--- a/src/components/PaceSpinBreakdown.jsx
+++ b/src/components/PaceSpinBreakdown.jsx
@@ -50,23 +50,25 @@ const CustomTooltip = ({ active, payload, label }) => {
   return null;
 };
 
-const PaceSpinBreakdown = ({ stats, isMobile: isMobileProp }) => {
+const PaceSpinBreakdown = ({ stats, isMobile: isMobileProp, wrapInCard = true }) => {
   const [selectedMetric, setSelectedMetric] = useState('strike_rate');
   const theme = useTheme();
   const isMobileDetected = useMediaQuery(theme.breakpoints.down('sm'));
   const isMobile = isMobileProp !== undefined ? isMobileProp : isMobileDetected;
+  const Wrapper = wrapInCard ? Card : Box;
+  const wrapperProps = wrapInCard ? { isMobile } : { sx: { width: '100%' } };
 
   // Null safety check
   if (!stats?.phase_stats?.pace?.overall || !stats?.phase_stats?.spin?.overall) {
     return (
-      <Card isMobile={isMobile}>
+      <Wrapper {...wrapperProps}>
         <Typography variant={isMobile ? "h6" : "h5"} sx={{ fontWeight: 600, mb: 2 }}>
           Pace vs Spin Analysis
         </Typography>
         <Typography color="text.secondary">
           Pace/Spin breakdown data not available
         </Typography>
-      </Card>
+      </Wrapper>
     );
   }
 
@@ -91,7 +93,7 @@ const PaceSpinBreakdown = ({ stats, isMobile: isMobileProp }) => {
   const chartHeight = isMobile ? 350 : 400;
 
   return (
-    <Card isMobile={isMobile}>
+    <Wrapper {...wrapperProps}>
       <Box sx={{
         display: 'flex',
         justifyContent: 'space-between',
@@ -136,7 +138,7 @@ const PaceSpinBreakdown = ({ stats, isMobile: isMobileProp }) => {
           </BarChart>
         </ResponsiveContainer>
       </Box>
-    </Card>
+    </Wrapper>
   );
 };
 

--- a/src/components/PhasePerformanceRadar.jsx
+++ b/src/components/PhasePerformanceRadar.jsx
@@ -40,7 +40,7 @@ const transformPhaseData = (stats, type = 'overall') => {
   return phaseData;
 };
 
-const PhasePerformanceRadar = ({ stats, isMobile: isMobileProp }) => {
+const PhasePerformanceRadar = ({ stats, isMobile: isMobileProp, wrapInCard = true }) => {
   const [selectedView, setSelectedView] = useState('overall');
   const theme = useTheme();
   const isMobileDetected = useMediaQuery(theme.breakpoints.down('sm'));
@@ -77,8 +77,11 @@ const PhasePerformanceRadar = ({ stats, isMobile: isMobileProp }) => {
     if (key === 'view') setSelectedView(value);
   };
 
+  const Wrapper = wrapInCard ? Card : Box;
+  const wrapperProps = wrapInCard ? { isMobile } : { sx: { width: '100%' } };
+
   return (
-    <Card isMobile={isMobile}>
+    <Wrapper {...wrapperProps}>
       <Box sx={{
         display: 'flex',
         justifyContent: 'space-between',
@@ -135,7 +138,7 @@ const PhasePerformanceRadar = ({ stats, isMobile: isMobileProp }) => {
           </RadarChart>
         </ResponsiveContainer>
       </Box>
-    </Card>
+    </Wrapper>
   );
 };
 

--- a/src/components/PlayerPitchMap.jsx
+++ b/src/components/PlayerPitchMap.jsx
@@ -26,11 +26,14 @@ const PlayerPitchMap = ({
   leagues = [],
   includeInternational = false,
   topTeams = null,
-  isMobile = false
+  isMobile = false,
+  wrapInCard = true
 }) => {
   const [pitchData, setPitchData] = useState(null);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState(null);
+  const Wrapper = wrapInCard ? Card : Box;
+  const wrapperProps = wrapInCard ? { isMobile } : { sx: { width: '100%' } };
 
   // Filters
   const [phase, setPhase] = useState('overall');
@@ -206,7 +209,7 @@ const PlayerPitchMap = ({
   };
 
   return (
-    <Card isMobile={isMobile}>
+    <Wrapper {...wrapperProps}>
       {/* Title and Filters in one row */}
       <Box sx={{
         display: 'flex',
@@ -249,7 +252,7 @@ const PlayerPitchMap = ({
           hideLegend={true}
         />
       </Box>
-    </Card>
+    </Wrapper>
   );
 };
 

--- a/src/components/PlayerProfile.jsx
+++ b/src/components/PlayerProfile.jsx
@@ -31,7 +31,7 @@ import config from '../config';
 import PlayerDNASummary from './PlayerDNASummary';
 import WagonWheel from './WagonWheel';
 import PlayerPitchMap from './PlayerPitchMap';
-import { FilterDrawer, MobileStickyHeader } from './ui';
+import { FilterDrawer, MobileStickyHeader, Section, VisualizationCard } from './ui';
 import { colors, spacing, typography, borderRadius, zIndex } from '../theme/designSystem';
 
 const DEFAULT_START_DATE = "2020-01-01";
@@ -462,69 +462,108 @@ const PlayerProfile = () => {
 
             {stats && !loading && (
               <Box sx={{ mt: isMobile ? 2 : 0 }}>
-                <CareerStatsCards stats={stats} isMobile={isMobile} />
+                <Section title="Career Overview" isMobile={isMobile} columns="1fr" disableTopSpacing>
+                  <CareerStatsCards stats={stats} isMobile={isMobile} />
 
-                <PlayerDNASummary
-                  playerName={selectedPlayer}
-                  startDate={dateRange.start}
-                  endDate={dateRange.end}
-                  leagues={competitionFilters.leagues}
-                  includeInternational={competitionFilters.international}
-                  topTeams={competitionFilters.topTeams}
-                  venue={selectedVenue !== 'All Venues' ? selectedVenue : null}
-                  fetchTrigger={dnaFetchTrigger}
+                  <PlayerDNASummary
+                    playerName={selectedPlayer}
+                    startDate={dateRange.start}
+                    endDate={dateRange.end}
+                    leagues={competitionFilters.leagues}
+                    includeInternational={competitionFilters.international}
+                    topTeams={competitionFilters.topTeams}
+                    venue={selectedVenue !== 'All Venues' ? selectedVenue : null}
+                    fetchTrigger={dnaFetchTrigger}
+                    isMobile={isMobile}
+                  />
+
+                  <VisualizationCard title="Contribution Timeline" isMobile={isMobile}>
+                    <ContributionGraph
+                      innings={stats.innings || []}
+                      mode="batter"
+                      dateRange={dateRange}
+                      isMobile={isMobile}
+                    />
+                  </VisualizationCard>
+                </Section>
+
+                <Section
+                  title="Shot Analysis"
                   isMobile={isMobile}
-                />
+                  columns={{ xs: '1fr', md: 'repeat(2, minmax(0, 1fr))' }}
+                >
+                  <VisualizationCard isMobile={isMobile}>
+                    <WagonWheel
+                      playerName={selectedPlayer}
+                      startDate={dateRange.start}
+                      endDate={dateRange.end}
+                      venue={selectedVenue !== 'All Venues' ? selectedVenue : null}
+                      leagues={competitionFilters.leagues}
+                      includeInternational={competitionFilters.international}
+                      topTeams={competitionFilters.topTeams}
+                      isMobile={isMobile}
+                      wrapInCard={false}
+                    />
+                  </VisualizationCard>
+                  <VisualizationCard isMobile={isMobile}>
+                    <PlayerPitchMap
+                      playerName={selectedPlayer}
+                      startDate={dateRange.start}
+                      endDate={dateRange.end}
+                      venue={selectedVenue !== 'All Venues' ? selectedVenue : null}
+                      leagues={competitionFilters.leagues}
+                      includeInternational={competitionFilters.international}
+                      topTeams={competitionFilters.topTeams}
+                      isMobile={isMobile}
+                      wrapInCard={false}
+                    />
+                  </VisualizationCard>
+                </Section>
 
-                <Box sx={{ mt: isMobile ? 2 : 3 }}>
-                  <ContributionGraph
-                    innings={stats.innings || []}
-                    mode="batter"
-                    dateRange={dateRange}
-                    isMobile={isMobile}
-                  />
-                </Box>
+                <Section
+                  title="Performance Breakdown"
+                  isMobile={isMobile}
+                  columns={{ xs: '1fr', md: 'repeat(2, minmax(0, 1fr))' }}
+                >
+                  <VisualizationCard isMobile={isMobile}>
+                    <PhasePerformanceRadar stats={stats} isMobile={isMobile} wrapInCard={false} />
+                  </VisualizationCard>
+                  <VisualizationCard isMobile={isMobile}>
+                    <PaceSpinBreakdown stats={stats} isMobile={isMobile} wrapInCard={false} />
+                  </VisualizationCard>
+                  <VisualizationCard isMobile={isMobile}>
+                    <InningsScatter innings={stats.innings} isMobile={isMobile} wrapInCard={false} />
+                  </VisualizationCard>
+                  <VisualizationCard isMobile={isMobile}>
+                    <StrikeRateProgression
+                      selectedPlayer={selectedPlayer}
+                      dateRange={dateRange}
+                      selectedVenue={selectedVenue}
+                      competitionFilters={competitionFilters}
+                      isMobile={isMobile}
+                      wrapInCard={false}
+                    />
+                  </VisualizationCard>
+                  <VisualizationCard isMobile={isMobile}>
+                    <BallRunDistribution innings={stats.innings} isMobile={isMobile} wrapInCard={false} />
+                  </VisualizationCard>
+                  <VisualizationCard isMobile={isMobile}>
+                    <StrikeRateIntervals ballStats={stats.ball_by_ball_stats} isMobile={isMobile} wrapInCard={false} />
+                  </VisualizationCard>
+                </Section>
 
-                {/* Wagon Wheel and Pitch Map Visualizations */}
-                <Box sx={{ mt: isMobile ? 2 : 4, display: 'grid', gridTemplateColumns: { xs: '1fr', md: 'repeat(2, 1fr)' }, gap: isMobile ? 2 : 3 }}>
-                  <WagonWheel
-                    playerName={selectedPlayer}
-                    startDate={dateRange.start}
-                    endDate={dateRange.end}
-                    venue={selectedVenue !== 'All Venues' ? selectedVenue : null}
-                    leagues={competitionFilters.leagues}
-                    includeInternational={competitionFilters.international}
-                    topTeams={competitionFilters.topTeams}
-                    isMobile={isMobile}
-                  />
-                  <PlayerPitchMap
-                    playerName={selectedPlayer}
-                    startDate={dateRange.start}
-                    endDate={dateRange.end}
-                    venue={selectedVenue !== 'All Venues' ? selectedVenue : null}
-                    leagues={competitionFilters.leagues}
-                    includeInternational={competitionFilters.international}
-                    topTeams={competitionFilters.topTeams}
-                    isMobile={isMobile}
-                  />
-                </Box>
-
-                <Box sx={{ mt: isMobile ? 2 : 4, display: 'grid', gridTemplateColumns: { xs: '1fr', md: 'repeat(2, 1fr)' }, gap: isMobile ? 2 : 3 }}>
-                  <PhasePerformanceRadar stats={stats} isMobile={isMobile} />
-                  <PaceSpinBreakdown stats={stats} isMobile={isMobile} />
-                  <InningsScatter innings={stats.innings} isMobile={isMobile} />
-                  <StrikeRateProgression
-                    selectedPlayer={selectedPlayer}
-                    dateRange={dateRange}
-                    selectedVenue={selectedVenue}
-                    competitionFilters={competitionFilters}
-                    isMobile={isMobile}
-                  />
-                  <BallRunDistribution innings={stats.innings} isMobile={isMobile} />
-                  <StrikeRateIntervals ballStats={stats.ball_by_ball_stats} isMobile={isMobile} />
-                </Box>
-                <TopInnings innings={stats.innings} count={10} isMobile={isMobile} />
-                <BowlingMatchupMatrix stats={stats} isMobile={isMobile} />
+                <Section
+                  title="Performance Highlights"
+                  isMobile={isMobile}
+                  columns={{ xs: '1fr', lg: 'repeat(2, minmax(0, 1fr))' }}
+                >
+                  <VisualizationCard isMobile={isMobile}>
+                    <TopInnings innings={stats.innings} count={10} isMobile={isMobile} wrapInCard={false} />
+                  </VisualizationCard>
+                  <VisualizationCard isMobile={isMobile}>
+                    <BowlingMatchupMatrix stats={stats} isMobile={isMobile} wrapInCard={false} />
+                  </VisualizationCard>
+                </Section>
 
                 {/* Contextual Query Prompts */}
                 <ContextualQueryPrompts

--- a/src/components/StrikeRateIntervals.jsx
+++ b/src/components/StrikeRateIntervals.jsx
@@ -14,11 +14,13 @@ import Card from './ui/Card';
 import FilterBar from './ui/FilterBar';
 import { colors as designColors } from '../theme/designSystem';
 
-const StrikeRateIntervals = ({ ballStats = [], isMobile: isMobileProp }) => {  // Add default empty array
+const StrikeRateIntervals = ({ ballStats = [], isMobile: isMobileProp, wrapInCard = true }) => {  // Add default empty array
   const [interval, setInterval] = useState(5);
   const theme = useTheme();
   const isMobileDetected = useMediaQuery(theme.breakpoints.down('sm'));
   const isMobile = isMobileProp !== undefined ? isMobileProp : isMobileDetected;
+  const Wrapper = wrapInCard ? Card : Box;
+  const wrapperProps = wrapInCard ? { isMobile } : { sx: { width: '100%' } };
 
   const processData = () => {
     // Return early if no data
@@ -50,12 +52,12 @@ const StrikeRateIntervals = ({ ballStats = [], isMobile: isMobileProp }) => {  /
   // If no data, show a message
   if (!ballStats || ballStats.length === 0) {
     return (
-      <Card isMobile={isMobile}>
+      <Wrapper {...wrapperProps}>
         <Typography variant={isMobile ? "h6" : "h5"} sx={{ fontWeight: 600, mb: 1 }}>
           Strike Rate Progression by Intervals
         </Typography>
         <Typography variant="body1" sx={{ mt: 2 }}>No data available</Typography>
-      </Card>
+      </Wrapper>
     );
   }
 
@@ -95,7 +97,7 @@ const StrikeRateIntervals = ({ ballStats = [], isMobile: isMobileProp }) => {  /
   const chartHeight = isMobile ? 350 : 400;
 
   return (
-    <Card isMobile={isMobile}>
+    <Wrapper {...wrapperProps}>
       <Box sx={{
         display: 'flex',
         justifyContent: 'space-between',
@@ -179,7 +181,7 @@ const StrikeRateIntervals = ({ ballStats = [], isMobile: isMobileProp }) => {  /
           </BarChart>
         </ResponsiveContainer>
       </Box>
-    </Card>
+    </Wrapper>
   );
 };
 

--- a/src/components/StrikeRateProgression.jsx
+++ b/src/components/StrikeRateProgression.jsx
@@ -5,11 +5,13 @@ import Card from './ui/Card';
 import { colors as designColors } from '../theme/designSystem';
 import config from '../config';
 
-const StrikeRateProgression = ({ selectedPlayer, dateRange, selectedVenue, competitionFilters, shouldFetch, isMobile: isMobileProp }) => {
+const StrikeRateProgression = ({ selectedPlayer, dateRange, selectedVenue, competitionFilters, shouldFetch, isMobile: isMobileProp, wrapInCard = true }) => {
   const [data, setData] = useState([]);
   const theme = useTheme();
   const isMobileDetected = useMediaQuery(theme.breakpoints.down('sm'));
   const isMobile = isMobileProp !== undefined ? isMobileProp : isMobileDetected;
+  const Wrapper = wrapInCard ? Card : Box;
+  const wrapperProps = wrapInCard ? { isMobile } : { sx: { width: '100%' } };
 
   useEffect(() => {
     const fetchData = async () => {
@@ -51,7 +53,7 @@ const StrikeRateProgression = ({ selectedPlayer, dateRange, selectedVenue, compe
   const chartHeight = isMobile ? 350 : 400;
 
   return (
-    <Card isMobile={isMobile}>
+    <Wrapper {...wrapperProps}>
       <Typography variant={isMobile ? "h6" : "h5"} sx={{ fontWeight: 600, mb: 2 }}>
         nth Ball SR
       </Typography>
@@ -123,7 +125,7 @@ const StrikeRateProgression = ({ selectedPlayer, dateRange, selectedVenue, compe
           </LineChart>
         </ResponsiveContainer>
       </Box>
-    </Card>
+    </Wrapper>
   );
 };
 

--- a/src/components/TopInnings.jsx
+++ b/src/components/TopInnings.jsx
@@ -12,8 +12,10 @@ import {
 import Card from './ui/Card';
 import FilterBar from './ui/FilterBar';
 
-const TopInnings = ({ innings, count = 10, isMobile = false }) => {
+const TopInnings = ({ innings, count = 10, isMobile = false, wrapInCard = true }) => {
   const [viewMode, setViewMode] = useState('topScoring');
+  const Wrapper = wrapInCard ? Card : Box;
+  const wrapperProps = wrapInCard ? { isMobile } : { sx: { width: '100%' } };
 
   const processedInnings = useMemo(() => {
     if (!innings?.length) return [];
@@ -72,7 +74,7 @@ const TopInnings = ({ innings, count = 10, isMobile = false }) => {
   };
 
   return (
-    <Card isMobile={isMobile}>
+    <Wrapper {...wrapperProps}>
       <Box sx={{
         display: 'flex',
         justifyContent: 'space-between',
@@ -148,7 +150,7 @@ const TopInnings = ({ innings, count = 10, isMobile = false }) => {
           </TableBody>
         </Table>
       </TableContainer>
-    </Card>
+    </Wrapper>
   );
 };
 

--- a/src/components/WagonWheel.jsx
+++ b/src/components/WagonWheel.jsx
@@ -26,11 +26,14 @@ const WagonWheel = ({
   leagues = [],
   includeInternational = false,
   topTeams = null,
-  isMobile = false
+  isMobile = false,
+  wrapInCard = true
 }) => {
   const [wagonData, setWagonData] = useState(null);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState(null);
+  const Wrapper = wrapInCard ? Card : Box;
+  const wrapperProps = wrapInCard ? { isMobile } : { sx: { width: '100%' } };
 
   // Filters
   const [phase, setPhase] = useState('overall');
@@ -366,7 +369,7 @@ const WagonWheel = ({
   };
 
   return (
-    <Card isMobile={isMobile}>
+    <Wrapper {...wrapperProps}>
       {/* Title and Filters in one row */}
       <Box sx={{
         display: 'flex',
@@ -423,7 +426,7 @@ const WagonWheel = ({
       <Box sx={{ display: 'flex', justifyContent: 'center' }}>
         {renderWagonWheel()}
       </Box>
-    </Card>
+    </Wrapper>
   );
 };
 

--- a/src/components/ui/VisualizationCard.jsx
+++ b/src/components/ui/VisualizationCard.jsx
@@ -1,38 +1,32 @@
 /**
- * Section Component - consistent section layout with header + grid
+ * VisualizationCard Component - consistent visualization container with slots
  */
 import React from 'react';
 import { Box, Typography } from '@mui/material';
+import Card from './Card';
 import { colors, spacing, typography } from '../../theme/designSystem';
 
-const Section = ({
+const VisualizationCard = ({
   title,
   subtitle,
   actions,
   children,
   isMobile = false,
-  columns = { xs: '1fr', md: 'repeat(2, minmax(0, 1fr))' },
-  gap,
-  disableTopSpacing = false,
   sx = {},
   headerSx = {},
   contentSx = {},
-  paddingX,
-  paddingY,
+  ...props
 }) => {
-  const contentGap = gap ?? (isMobile ? spacing.base : spacing.lg);
-
   return (
-    <Box
+    <Card
+      isMobile={isMobile}
       sx={{
-        mt: disableTopSpacing ? 0 : `${spacing.section}px`,
-        px: paddingX ?? 0,
-        py: paddingY ?? 0,
         display: 'flex',
         flexDirection: 'column',
         gap: `${spacing.base}px`,
         ...sx,
       }}
+      {...props}
     >
       {(title || subtitle || actions) && (
         <Box
@@ -60,7 +54,10 @@ const Section = ({
             {subtitle && (
               <Typography
                 variant="body2"
-                sx={{ mt: `${spacing.xs}px`, color: colors.neutral[600] }}
+                sx={{
+                  mt: `${spacing.xs}px`,
+                  color: colors.neutral[600],
+                }}
               >
                 {subtitle}
               </Typography>
@@ -70,18 +67,9 @@ const Section = ({
         </Box>
       )}
 
-      <Box
-        sx={{
-          display: 'grid',
-          gridTemplateColumns: columns,
-          gap: `${contentGap}px`,
-          ...contentSx,
-        }}
-      >
-        {children}
-      </Box>
-    </Box>
+      <Box sx={{ width: '100%', ...contentSx }}>{children}</Box>
+    </Card>
   );
 };
 
-export default Section;
+export default VisualizationCard;

--- a/src/components/ui/index.js
+++ b/src/components/ui/index.js
@@ -6,3 +6,4 @@ export { default as MobileStickyHeader } from './MobileStickyHeader';
 export { default as Section } from './Section';
 export { default as Skeleton } from './Skeleton';
 export { default as StatCard } from './StatCard';
+export { default as VisualizationCard } from './VisualizationCard';

--- a/src/theme/designSystem.js
+++ b/src/theme/designSystem.js
@@ -18,6 +18,7 @@ export const spacing = {
   xl: 32,
   xxl: 48,
   xxxl: 64,
+  section: 40,
 };
 
 // Color palette


### PR DESCRIPTION
### Motivation

- Standardize visualization containers and headers so charts share consistent padding, radius, border and shadows using design tokens.  
- Group related visualizations into named sections (e.g. “Career Overview”, “Shot Analysis”, “Performance Breakdown”) with consistent vertical spacing.  
- Allow charts to be embedded inside a shared container without duplicating card chrome to enable cleaner grid layouts.  
- Surface a single design token for section spacing (`spacing.section`) so vertical rhythm is consistent across pages.

### Description

- Add `VisualizationCard` component as a thin, token-driven wrapper that provides title/subtitle/action slots and uses `Card` tokens for padding and elevation.  
- Add `Section` component for section headers, responsive grid layout and spacing, and introduce `spacing.section` token in `src/theme/designSystem.js`.  
- Refactor `PlayerProfile.jsx` to group visualizations into `Section`s and wrap individual charts in `VisualizationCard`s for consistent headers and spacing.  
- Update many visualization components to accept `wrapInCard` / `wrapInCard = true` (or `wrapInCard`/`wrapInCard = false`) and use a `Wrapper` (`Card` or `Box`) so charts can render without their internal `Card` when embedded (components updated include `WagonWheel`, `PlayerPitchMap`, `PhasePerformanceRadar`, `PaceSpinBreakdown`, `InningsScatter`, `StrikeRateProgression`, `BallRunDistribution`, `StrikeRateIntervals`, `TopInnings`, and `BowlingMatchupMatrix`), and export `VisualizationCard` / `Section` from `src/components/ui/index.js`.

### Testing

- No unit tests were executed as part of this change.  
- A Playwright script was attempted to load `http://localhost:3000/player` and capture a screenshot, but it failed with `net::ERR_EMPTY_RESPONSE`.  
- All code edits were compiled and staged into a single commit locally (`Add sectioned visualization cards to player profile`).  
- No automated style/lint or CI runs were performed in this rollout.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6959f3d32f3c832cb70528e4d49d8de1)