### PR TITLE
Align player profile typography with design system tokens

### DIFF
--- a/src/components/CareerStatsCards.jsx
+++ b/src/components/CareerStatsCards.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { Box, Typography } from '@mui/material';
+import { spacing } from '../theme/designSystem';
 import Card from './ui/Card';
 
 const CareerStatsCards = ({ stats, isMobile = false }) => {
@@ -8,49 +9,49 @@ const CareerStatsCards = ({ stats, isMobile = false }) => {
   return (
     <Box sx={{
       display: 'grid',
-      gap: 2,
+      gap: `${spacing.lg}px`,
       gridTemplateColumns: '1fr',
-      mb: 3
+      mb: `${spacing.xl}px`
     }}>
       {/* Primary Stats Card */}
       <Card isMobile={isMobile}>
         <Box sx={{
           display: 'grid',
           gridTemplateColumns: { xs: 'repeat(2, 1fr)', md: 'repeat(4, 1fr)' },
-          gap: { xs: 2, md: 3 }
+          gap: { xs: `${spacing.base}px`, md: `${spacing.lg}px` }
         }}>
           <Box>
-            <Typography variant="caption" color="text.secondary" sx={{ fontSize: isMobile ? '0.7rem' : '0.75rem', fontWeight: 600 }}>
+            <Typography variant="caption" color="text.secondary" sx={{ fontWeight: 600 }}>
               MATCHES
             </Typography>
-            <Typography variant={isMobile ? "h5" : "h4"} sx={{ fontWeight: 700, mt: 0.5 }}>
+            <Typography variant={isMobile ? "h5" : "h4"} sx={{ fontWeight: 700, mt: `${spacing.xs}px` }}>
               {overall.matches}
             </Typography>
           </Box>
           <Box>
-            <Typography variant="caption" color="text.secondary" sx={{ fontSize: isMobile ? '0.7rem' : '0.75rem', fontWeight: 600 }}>
+            <Typography variant="caption" color="text.secondary" sx={{ fontWeight: 600 }}>
               RUNS
             </Typography>
-            <Typography variant={isMobile ? "h5" : "h4"} sx={{ fontWeight: 700, mt: 0.5 }}>
+            <Typography variant={isMobile ? "h5" : "h4"} sx={{ fontWeight: 700, mt: `${spacing.xs}px` }}>
               {overall.runs}
             </Typography>
-            <Typography variant="caption" color="text.secondary" sx={{ fontSize: isMobile ? '0.65rem' : '0.7rem' }}>
+            <Typography variant="caption" color="text.secondary">
               Avg: {overall.average.toFixed(2)}
             </Typography>
           </Box>
           <Box>
-            <Typography variant="caption" color="text.secondary" sx={{ fontSize: isMobile ? '0.7rem' : '0.75rem', fontWeight: 600 }}>
+            <Typography variant="caption" color="text.secondary" sx={{ fontWeight: 600 }}>
               STRIKE RATE
             </Typography>
-            <Typography variant={isMobile ? "h5" : "h4"} sx={{ fontWeight: 700, mt: 0.5 }}>
+            <Typography variant={isMobile ? "h5" : "h4"} sx={{ fontWeight: 700, mt: `${spacing.xs}px` }}>
               {overall.strike_rate.toFixed(1)}
             </Typography>
           </Box>
           <Box>
-            <Typography variant="caption" color="text.secondary" sx={{ fontSize: isMobile ? '0.7rem' : '0.75rem', fontWeight: 600 }}>
+            <Typography variant="caption" color="text.secondary" sx={{ fontWeight: 600 }}>
               50s/100s
             </Typography>
-            <Typography variant={isMobile ? "h5" : "h4"} sx={{ fontWeight: 700, mt: 0.5 }}>
+            <Typography variant={isMobile ? "h5" : "h4"} sx={{ fontWeight: 700, mt: `${spacing.xs}px` }}>
               {overall.fifties}/{overall.hundreds}
             </Typography>
           </Box>
@@ -62,21 +63,21 @@ const CareerStatsCards = ({ stats, isMobile = false }) => {
         <Box sx={{
           display: 'grid',
           gridTemplateColumns: { xs: 'repeat(2, 1fr)', md: 'repeat(2, 1fr)' },
-          gap: { xs: 2, md: 3 }
+          gap: { xs: `${spacing.base}px`, md: `${spacing.lg}px` }
         }}>
           <Box>
-            <Typography variant="caption" color="text.secondary" sx={{ fontSize: isMobile ? '0.7rem' : '0.75rem', fontWeight: 600 }}>
+            <Typography variant="caption" color="text.secondary" sx={{ fontWeight: 600 }}>
               DOT %
             </Typography>
-            <Typography variant={isMobile ? "h5" : "h4"} sx={{ fontWeight: 700, mt: 0.5 }}>
+            <Typography variant={isMobile ? "h5" : "h4"} sx={{ fontWeight: 700, mt: `${spacing.xs}px` }}>
               {overall.dot_percentage.toFixed(1)}%
             </Typography>
           </Box>
           <Box>
-            <Typography variant="caption" color="text.secondary" sx={{ fontSize: isMobile ? '0.7rem' : '0.75rem', fontWeight: 600 }}>
+            <Typography variant="caption" color="text.secondary" sx={{ fontWeight: 600 }}>
               BOUNDARY %
             </Typography>
-            <Typography variant={isMobile ? "h5" : "h4"} sx={{ fontWeight: 700, mt: 0.5 }}>
+            <Typography variant={isMobile ? "h5" : "h4"} sx={{ fontWeight: 700, mt: `${spacing.xs}px` }}>
               {overall.boundary_percentage.toFixed(1)}%
             </Typography>
           </Box>

--- a/src/components/ContributionGraph.jsx
+++ b/src/components/ContributionGraph.jsx
@@ -1,4 +1,6 @@
 import React, { useMemo } from 'react';
+import { Box, Typography } from '@mui/material';
+import { borderRadius, colors, spacing, typography } from '../theme/designSystem';
 import { getBatterColor, getWeekStart } from './contributionGraphUtils';
 
 const DAYS = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'];
@@ -105,27 +107,31 @@ const ContributionGraph = ({ innings, playerName }) => {
   const svgHeight = TOP_PADDING + (7 * WEEK_WIDTH) + 10;
 
   return (
-    <div style={{ 
-      background: '#fff', 
-      borderRadius: '8px', 
-      padding: '16px',
-      border: '1px solid #e1e4e8',
-      marginBottom: '20px'
+    <Box sx={{
+      backgroundColor: colors.neutral[0],
+      borderRadius: `${borderRadius.base}px`,
+      p: `${spacing.base}px`,
+      border: `1px solid ${colors.neutral[200]}`,
+      mb: `${spacing.lg}px`
     }}>
-      <div style={{ marginBottom: '8px' }}>
-        <div style={{ fontWeight: 600, fontSize: '14px', marginBottom: '4px' }}>Performance Graph</div>
-        <div style={{ color: '#666', fontSize: '12px' }}>
-          <span>{stats.total} innings</span>
-          <span style={{ marginLeft: '12px' }}>
+      <Box sx={{ mb: `${spacing.sm}px` }}>
+        <Typography variant="h6" sx={{ fontWeight: 600, mb: `${spacing.xs}px` }}>
+          Performance Graph
+        </Typography>
+        <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: `${spacing.md}px`, color: 'text.secondary' }}>
+          <Typography variant="body2" component="span">
+            {stats.total} innings
+          </Typography>
+          <Typography variant="body2" component="span">
             Avg Fantasy: {stats.avgFantasy.toFixed(1)} pts
-          </span>
-          <span style={{ marginLeft: '12px' }}>
+          </Typography>
+          <Typography variant="body2" component="span">
             🦆 {stats.ducks} ducks
-          </span>
-        </div>
-      </div>
+          </Typography>
+        </Box>
+      </Box>
       
-      <div style={{ overflowX: 'auto' }}>
+      <Box sx={{ overflowX: 'auto' }}>
         <svg width={svgWidth} height={svgHeight} style={{ display: 'block' }}>
           {/* Month labels */}
           {monthLabels.map((label, idx) => {
@@ -147,8 +153,8 @@ const ContributionGraph = ({ innings, playerName }) => {
                 key={`${label.weekIndex}-${label.month}-${label.year}`}
                 x={LEFT_PADDING + (label.weekIndex * WEEK_WIDTH)}
                 y={10}
-                fontSize="9"
-                fill="#666"
+                fontSize={typography.fontSize.xs}
+                fill={colors.neutral[600]}
               >
                 {labelText}
               </text>
@@ -162,8 +168,8 @@ const ContributionGraph = ({ innings, playerName }) => {
                 key={day}
                 x={2}
                 y={TOP_PADDING + (idx * WEEK_WIDTH) + 8}
-                fontSize="9"
-                fill="#666"
+                fontSize={typography.fontSize.xs}
+                fill={colors.neutral[600]}
               >
                 {day}
               </text>
@@ -210,7 +216,7 @@ const ContributionGraph = ({ innings, playerName }) => {
                       <text
                         x={cellX + CELL_SIZE / 2}
                         y={cellY + CELL_SIZE / 2 + 1}
-                        fontSize="7"
+                        fontSize={typography.fontSize.xs}
                         textAnchor="middle"
                         dominantBaseline="middle"
                         style={{ pointerEvents: 'none', userSelect: 'none' }}
@@ -224,33 +230,35 @@ const ContributionGraph = ({ innings, playerName }) => {
             </g>
           ))}
         </svg>
-      </div>
+      </Box>
       
       {/* Legend */}
-      <div style={{ 
-        display: 'flex', 
-        alignItems: 'center', 
-        gap: '4px', 
-        marginTop: '8px',
-        fontSize: '11px',
-        color: '#666'
+      <Box sx={{
+        display: 'flex',
+        alignItems: 'center',
+        flexWrap: 'wrap',
+        gap: `${spacing.xs}px`,
+        mt: `${spacing.sm}px`,
+        color: 'text.secondary'
       }}>
-        <span>Less</span>
+        <Typography variant="caption" component="span">Less</Typography>
         {['#ebedf0', '#9be9a8', '#40c463', '#30a14e', '#216e39'].map((color, i) => (
-          <div
+          <Box
             key={i}
-            style={{
-              width: '10px',
-              height: '10px',
+            sx={{
+              width: `${spacing.sm}px`,
+              height: `${spacing.sm}px`,
               backgroundColor: color,
-              borderRadius: '2px'
+              borderRadius: `${borderRadius.sm}px`
             }}
           />
         ))}
-        <span>More</span>
-        <span style={{ marginLeft: '12px' }}>🦆 Duck</span>
-      </div>
-    </div>
+        <Typography variant="caption" component="span">More</Typography>
+        <Typography variant="caption" component="span" sx={{ ml: `${spacing.sm}px` }}>
+          🦆 Duck
+        </Typography>
+      </Box>
+    </Box>
   );
 };
 

--- a/src/components/PlayerDNASummary.jsx
+++ b/src/components/PlayerDNASummary.jsx
@@ -2,6 +2,7 @@ import React, { useState, useEffect } from 'react';
 import { Box, Card, CardContent, Typography, CircularProgress, Alert } from '@mui/material';
 import { Bolt as BoltIcon } from '@mui/icons-material';
 import axios from 'axios';
+import { spacing } from '../theme/designSystem';
 import config from '../config';
 
 const PlayerDNASummary = ({ 
@@ -74,12 +75,12 @@ const PlayerDNASummary = ({
   if (!playerName || !fetchTrigger) return null;
 
   return (
-    <Box sx={{ mt: 3 }}>
+    <Box sx={{ mt: `${spacing.lg}px` }}>
       <Card>
-        <CardContent sx={{ py: 2, '&:last-child': { pb: 2 } }}>
+        <CardContent sx={{ py: `${spacing.base}px`, '&:last-child': { pb: `${spacing.base}px` } }}>
           {/* Header */}
-          <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, mb: 1.5 }}>
-            <BoltIcon sx={{ color: 'primary.main', fontSize: 20 }} />
+          <Box sx={{ display: 'flex', alignItems: 'center', gap: `${spacing.sm}px`, mb: `${spacing.md}px` }}>
+            <BoltIcon sx={{ color: 'primary.main', fontSize: spacing.lg }} />
             <Typography variant="subtitle1" fontWeight="bold">
               Player DNA
             </Typography>
@@ -92,7 +93,7 @@ const PlayerDNASummary = ({
 
           {/* Loading State */}
           {loading && (
-            <Box sx={{ display: 'flex', alignItems: 'center', gap: 1.5, py: 2 }}>
+            <Box sx={{ display: 'flex', alignItems: 'center', gap: `${spacing.md}px`, py: `${spacing.base}px` }}>
               <CircularProgress size={18} />
               <Typography variant="body2" color="text.secondary">
                 Analyzing {playerType === 'bowler' ? 'bowling' : 'batting'} patterns...
@@ -102,16 +103,16 @@ const PlayerDNASummary = ({
 
           {/* Error State */}
           {error && !loading && (
-            <Alert severity="error" sx={{ py: 0.5 }}>
+            <Alert severity="error" sx={{ py: `${spacing.xs}px` }}>
               <Typography variant="body2">{error}</Typography>
             </Alert>
           )}
 
           {/* Summary Items */}
           {summary?.success && summary.summary && !loading && (
-            <Box sx={{ display: 'flex', flexDirection: 'column', gap: 0.75 }}>
+            <Box sx={{ display: 'flex', flexDirection: 'column', gap: `${spacing.xs}px` }}>
               {parseSummary(summary.summary).map((bullet, index) => (
-                <Box key={index} sx={{ display: 'flex', gap: 1, alignItems: 'flex-start' }}>
+                <Box key={index} sx={{ display: 'flex', gap: `${spacing.sm}px`, alignItems: 'flex-start' }}>
                   <Typography component="span" sx={{ flexShrink: 0 }}>
                     {bullet.emoji}
                   </Typography>

--- a/src/components/TopInnings.jsx
+++ b/src/components/TopInnings.jsx
@@ -11,6 +11,7 @@ import {
 } from '@mui/material';
 import Card from './ui/Card';
 import FilterBar from './ui/FilterBar';
+import { spacing } from '../theme/designSystem';
 
 const TopInnings = ({ innings, count = 10, isMobile = false, wrapInCard = true }) => {
   const [viewMode, setViewMode] = useState('topScoring');
@@ -79,8 +80,8 @@ const TopInnings = ({ innings, count = 10, isMobile = false, wrapInCard = true }
         display: 'flex',
         justifyContent: 'space-between',
         alignItems: 'center',
-        mb: isMobile ? 1.5 : 3,
-        gap: 1,
+        mb: isMobile ? `${spacing.md}px` : `${spacing.lg}px`,
+        gap: `${spacing.sm}px`,
         flexWrap: isMobile ? 'wrap' : 'nowrap'
       }}>
         <Typography variant={isMobile ? "h6" : "h5"} sx={{ fontWeight: 600, flexShrink: 0 }}>
@@ -100,21 +101,46 @@ const TopInnings = ({ innings, count = 10, isMobile = false, wrapInCard = true }
         <Table size={isMobile ? "small" : "medium"} sx={{
           '& .MuiTableCell-root': {
             borderBottom: '1px solid rgba(224, 224, 224, 1)',
-            py: isMobile ? 0.75 : 1.5,
-            px: isMobile ? 0.5 : 2,
-            fontSize: isMobile ? '0.7rem' : undefined
+            py: isMobile ? `${spacing.xs}px` : `${spacing.md}px`,
+            px: isMobile ? `${spacing.xs}px` : `${spacing.base}px`
           }
         }}>
           <TableHead>
             <TableRow>
-              <TableCell sx={{ fontWeight: 600 }}>{isMobile ? 'Date' : 'Date'}</TableCell>
-              <TableCell sx={{ fontWeight: 600 }}>Score</TableCell>
-              <TableCell sx={{ fontWeight: 600 }}>{isMobile ? 'Opp' : 'Opposition'}</TableCell>
-              <TableCell align="right" sx={{ fontWeight: 600 }}>SR</TableCell>
-              {!isMobile && <TableCell align="right" sx={{ fontWeight: 600 }}>SR Diff</TableCell>}
-              {!isMobile && <TableCell align="right" sx={{ fontWeight: 600 }}>% Team</TableCell>}
-              {!isMobile && <TableCell sx={{ fontWeight: 600 }}>Context</TableCell>}
-              {!isMobile && <TableCell align="right" sx={{ fontWeight: 600 }}>Winner</TableCell>}
+              <TableCell sx={{ fontWeight: 600 }}>
+                <Typography variant={isMobile ? 'caption' : 'body2'}>Date</Typography>
+              </TableCell>
+              <TableCell sx={{ fontWeight: 600 }}>
+                <Typography variant={isMobile ? 'caption' : 'body2'}>Score</Typography>
+              </TableCell>
+              <TableCell sx={{ fontWeight: 600 }}>
+                <Typography variant={isMobile ? 'caption' : 'body2'}>
+                  {isMobile ? 'Opp' : 'Opposition'}
+                </Typography>
+              </TableCell>
+              <TableCell align="right" sx={{ fontWeight: 600 }}>
+                <Typography variant={isMobile ? 'caption' : 'body2'}>SR</Typography>
+              </TableCell>
+              {!isMobile && (
+                <TableCell align="right" sx={{ fontWeight: 600 }}>
+                  <Typography variant="body2">SR Diff</Typography>
+                </TableCell>
+              )}
+              {!isMobile && (
+                <TableCell align="right" sx={{ fontWeight: 600 }}>
+                  <Typography variant="body2">% Team</Typography>
+                </TableCell>
+              )}
+              {!isMobile && (
+                <TableCell sx={{ fontWeight: 600 }}>
+                  <Typography variant="body2">Context</Typography>
+                </TableCell>
+              )}
+              {!isMobile && (
+                <TableCell align="right" sx={{ fontWeight: 600 }}>
+                  <Typography variant="body2">Winner</Typography>
+                </TableCell>
+              )}
             </TableRow>
           </TableHead>
           <TableBody>
@@ -127,24 +153,50 @@ const TopInnings = ({ innings, count = 10, isMobile = false, wrapInCard = true }
                 }}
               >
                 <TableCell sx={{ whiteSpace: 'nowrap' }}>
-                  {isMobile
-                    ? inning.date.toLocaleDateString('en-GB', { day: '2-digit', month: 'short' })
-                    : inning.date.toLocaleDateString('en-GB', { day: 'numeric', month: 'short', year: 'numeric' })
-                  }
+                  <Typography variant={isMobile ? 'caption' : 'body2'}>
+                    {isMobile
+                      ? inning.date.toLocaleDateString('en-GB', { day: '2-digit', month: 'short' })
+                      : inning.date.toLocaleDateString('en-GB', { day: 'numeric', month: 'short', year: 'numeric' })
+                    }
+                  </Typography>
                 </TableCell>
-                <TableCell sx={{ whiteSpace: 'nowrap' }}>{inning.runs}({inning.balls_faced})</TableCell>
+                <TableCell sx={{ whiteSpace: 'nowrap' }}>
+                  <Typography variant={isMobile ? 'caption' : 'body2'}>
+                    {inning.runs}({inning.balls_faced})
+                  </Typography>
+                </TableCell>
                 <TableCell sx={{ whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis', maxWidth: isMobile ? 60 : 'auto' }}>
-                  {isMobile ? inning.bowling_team.substring(0, 3).toUpperCase() : inning.bowling_team}
+                  <Typography variant={isMobile ? 'caption' : 'body2'}>
+                    {isMobile ? inning.bowling_team.substring(0, 3).toUpperCase() : inning.bowling_team}
+                  </Typography>
                 </TableCell>
-                <TableCell align="right">{inning.strike_rate.toFixed(1)}</TableCell>
-                {!isMobile && <TableCell align="right">{inning.team_comparison.sr_diff.toFixed(1)}</TableCell>}
+                <TableCell align="right">
+                  <Typography variant={isMobile ? 'caption' : 'body2'}>
+                    {inning.strike_rate.toFixed(1)}
+                  </Typography>
+                </TableCell>
                 {!isMobile && (
                   <TableCell align="right">
-                    {inning.runPercentage.toFixed(1)}% ({inning.runs}/{inning.totalTeamRuns})
+                    <Typography variant="body2">{inning.team_comparison.sr_diff.toFixed(1)}</Typography>
                   </TableCell>
                 )}
-                {!isMobile && <TableCell>{inning.venue}, {inning.competition}</TableCell>}
-                {!isMobile && <TableCell align="right">{inning.winner}</TableCell>}
+                {!isMobile && (
+                  <TableCell align="right">
+                    <Typography variant="body2">
+                      {inning.runPercentage.toFixed(1)}% ({inning.runs}/{inning.totalTeamRuns})
+                    </Typography>
+                  </TableCell>
+                )}
+                {!isMobile && (
+                  <TableCell>
+                    <Typography variant="body2">{inning.venue}, {inning.competition}</Typography>
+                  </TableCell>
+                )}
+                {!isMobile && (
+                  <TableCell align="right">
+                    <Typography variant="body2">{inning.winner}</Typography>
+                  </TableCell>
+                )}
               </TableRow>
             ))}
           </TableBody>

--- a/src/theme/designSystem.js
+++ b/src/theme/designSystem.js
@@ -123,6 +123,45 @@ export const typography = {
   },
 };
 
+// Typography usage guide mapped to MUI variants
+export const typographyUsage = {
+  h1: {
+    label: 'H1',
+    muiVariant: 'h1',
+    fontSize: typography.fontSize['4xl'],
+    fontWeight: typography.fontWeight.bold,
+    lineHeight: typography.lineHeight.tight,
+  },
+  h2: {
+    label: 'H2',
+    muiVariant: 'h2',
+    fontSize: typography.fontSize['3xl'],
+    fontWeight: typography.fontWeight.bold,
+    lineHeight: typography.lineHeight.tight,
+  },
+  h3: {
+    label: 'H3',
+    muiVariant: 'h3',
+    fontSize: typography.fontSize['2xl'],
+    fontWeight: typography.fontWeight.semibold,
+    lineHeight: typography.lineHeight.tight,
+  },
+  body: {
+    label: 'Body',
+    muiVariant: 'body1',
+    fontSize: typography.fontSize.base,
+    fontWeight: typography.fontWeight.normal,
+    lineHeight: typography.lineHeight.normal,
+  },
+  caption: {
+    label: 'Caption',
+    muiVariant: 'caption',
+    fontSize: typography.fontSize.xs,
+    fontWeight: typography.fontWeight.normal,
+    lineHeight: typography.lineHeight.normal,
+  },
+};
+
 // Border radius scale
 export const borderRadius = {
   none: 0,
@@ -338,6 +377,7 @@ export default {
   spacing,
   colors,
   typography,
+  typographyUsage,
   borderRadius,
   shadows,
   transitions,

--- a/src/theme/index.js
+++ b/src/theme/index.js
@@ -1,7 +1,14 @@
 import { createTheme } from '@mui/material/styles';
-import designSystem, { muiTheme } from './designSystem';
+import designSystem, { muiTheme, typography } from './designSystem';
 
 const theme = createTheme(muiTheme);
+
+theme.typography.h3 = {
+  ...theme.typography.h3,
+  [theme.breakpoints.down('sm')]: {
+    fontSize: typography.fontSize.xl,
+  },
+};
 
 export { theme };
 export * from './designSystem';


### PR DESCRIPTION
### Motivation
- Provide a clear typography usage guide and map H1/H2/H3/Body/Caption to MUI variants for consistent text styles across the app.
- Replace ad-hoc font sizes in PlayerProfile-related components with theme typography variants to improve consistency and accessibility.
- Replace scattered numeric margins/padding with the design system spacing scale to unify layout spacing.
- Add a responsive typography rule so `h3` scales down on small screens for better mobile legibility.

### Description
- Added `typographyUsage` to `src/theme/designSystem.js` and exported it for reference, mapping `h1/h2/h3/body/caption` to MUI variants and token values.
- Added a responsive override for `h3` in `src/theme/index.js` using the design system `typography` values and MUI breakpoints.
- Updated `src/components/CareerStatsCards.jsx`, `src/components/TopInnings.jsx`, `src/components/ContributionGraph.jsx`, and `src/components/PlayerDNASummary.jsx` to use theme `spacing` tokens and MUI `Typography` variants instead of ad-hoc font sizes and numeric `mt/mb` values.
- Refactored `ContributionGraph` to use `Box`/`Typography` and design tokens (`spacing`, `colors`, `borderRadius`, `typography`) for labels, legend and container styling.

### Testing
- Ran `npm start` to boot the development server, which started the CRA dev server (startup logged successfully).
- Attempted a Playwright screenshot of `/player` to visually validate changes, but the Chromium process crashed with a SIGSEGV and the capture failed.
- No unit or integration test suites were executed as part of this change.
- All code changes were committed (see commit message: `Align player profile typography with design system`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6959f76c9e7c832c8e2395a857ba23c0)