### PR TITLE
Add share framing and compact/mobile styling for visualization components

### DIFF
--- a/src/components/InningsScatter.jsx
+++ b/src/components/InningsScatter.jsx
@@ -14,13 +14,19 @@ import Card from './ui/Card';
 import FilterBar from './ui/FilterBar';
 import { colors as designColors } from '../theme/designSystem';
 
-const InningsScatter = ({ innings, wrapInCard = true }) => {
+const InningsScatter = ({ innings, wrapInCard = true, shareView = false }) => {
   const [xMetric, setXMetric] = useState('balls');
   const [yMetric, setYMetric] = useState('strike_rate');
   const theme = useTheme();
   const isMobile = useMediaQuery(theme.breakpoints.down('sm'));
+  const isCompact = shareView || isMobile;
   const Wrapper = wrapInCard ? Card : Box;
-  const wrapperProps = wrapInCard ? { isMobile } : { sx: { width: '100%' } };
+  const frameSx = isMobile
+    ? { minHeight: 420, aspectRatio: '4 / 5' }
+    : {};
+  const wrapperProps = wrapInCard
+    ? { isMobile, shareFrame: shareView, sx: frameSx }
+    : { sx: { width: '100%', ...frameSx } };
 
   const getPhase = (over) => {
     if (over < 6) return 0;
@@ -106,7 +112,7 @@ const InningsScatter = ({ innings, wrapInCard = true }) => {
   };
 
   // Responsive height calculation - fits in mobile viewport for screenshots
-  const chartHeight = isMobile ?
+  const chartHeight = isCompact ?
     Math.min(typeof window !== 'undefined' ? window.innerHeight * 0.55 : 400, 450) :
     400;
 
@@ -130,16 +136,16 @@ const InningsScatter = ({ innings, wrapInCard = true }) => {
 
   return (
     <Wrapper {...wrapperProps}>
-      <Typography variant={isMobile ? "h6" : "h5"} sx={{ fontWeight: 600, mb: 2 }}>
+      <Typography variant={isCompact ? "h6" : "h5"} sx={{ fontWeight: 600, mb: isCompact ? 1.5 : 2 }}>
         Balls Faced vs Runs
       </Typography>
 
-      <Box sx={{ mb: isMobile ? 2 : 3 }}>
+      <Box sx={{ mb: isCompact ? 1.5 : 3 }}>
         <FilterBar
           filters={filterConfig}
           activeFilters={{ xAxis: xMetric, yAxis: yMetric }}
           onFilterChange={handleFilterChange}
-          isMobile={isMobile}
+          isMobile={isCompact}
         />
       </Box>
 
@@ -157,7 +163,7 @@ const InningsScatter = ({ innings, wrapInCard = true }) => {
               dataKey={xAxisMetrics[xMetric].key}
               name={xAxisMetrics[xMetric].label}
               label={isMobile ? undefined : { value: xAxisMetrics[xMetric].label, position: 'bottom', offset: 0 }}
-              tick={{ fontSize: isMobile ? 9 : 12 }}
+              tick={{ fontSize: isCompact ? 8 : 12 }}
             />
             <YAxis
               type="number"
@@ -169,17 +175,17 @@ const InningsScatter = ({ innings, wrapInCard = true }) => {
                 position: 'insideLeft',
                 offset: 10
               }}
-              tick={{ fontSize: isMobile ? 9 : 12 }}
+              tick={{ fontSize: isCompact ? 8 : 12 }}
             />
-            {yMetric === 'strike_rate' && <ReferenceLine y={100} stroke="#666" strokeDasharray="3 3" />}
-            {yMetric === 'sr_diff' && <ReferenceLine y={0} stroke="#666" strokeDasharray="3 3" />}
+            {yMetric === 'strike_rate' && <ReferenceLine y={100} stroke={designColors.neutral[500]} strokeDasharray="3 3" />}
+            {yMetric === 'sr_diff' && <ReferenceLine y={0} stroke={designColors.neutral[500]} strokeDasharray="3 3" />}
             <Tooltip content={<CustomTooltip />} />
             <Scatter
               name="Innings"
               data={data}
-              fill={designColors.primary[500]}
+              fill={designColors.chart.blue}
               opacity={0.6}
-              r={isMobile ? 5 : 6}
+              r={isCompact ? 4.5 : 6}
             />
           </ScatterChart>
         </ResponsiveContainer>

--- a/src/components/PitchMap/PitchMapVisualization.jsx
+++ b/src/components/PitchMap/PitchMapVisualization.jsx
@@ -7,6 +7,7 @@
 
 import React from 'react';
 import { Box, Typography, Tooltip } from '@mui/material';
+import { colors } from '../../theme/designSystem';
 import {
   PITCH_DIMENSIONS,
   LINE_ORDER,
@@ -34,7 +35,8 @@ const PitchMapVisualization = ({
   width: propWidth,
   svgRef,
   hideStumps = false,
-  hideLegend = false
+  hideLegend = false,
+  compactMode = false
 }) => {
   // Use ref to measure container if no width prop
   const [containerWidth, setContainerWidth] = React.useState(propWidth || PITCH_DIMENSIONS.width);
@@ -61,7 +63,7 @@ const PitchMapVisualization = ({
   
   const scaledDimensions = {
     width,
-    height: Math.max(550, PITCH_DIMENSIONS.height * scale),
+    height: Math.max(compactMode ? 480 : 550, PITCH_DIMENSIONS.height * scale),
     pitchWidth: (width - (PITCH_DIMENSIONS.padding.left + PITCH_DIMENSIONS.padding.right) * scale),
     pitchHeight: PITCH_DIMENSIONS.pitchHeight * scale,
     cellHeight,
@@ -127,12 +129,12 @@ const PitchMapVisualization = ({
     }
     
     // Take the minimum of width and height constraints, cap at reasonable max
-    const primaryFontSize = Math.min(maxPrimaryByWidth, maxPrimaryByHeight, 13);
-    const secondaryFontSize = Math.min(maxSecondaryByWidth, maxSecondaryByHeight, 11);
+    const primaryFontSize = Math.min(maxPrimaryByWidth, maxPrimaryByHeight, compactMode ? 11 : 13);
+    const secondaryFontSize = Math.min(maxSecondaryByWidth, maxSecondaryByHeight, compactMode ? 9 : 11);
     
     return {
-      primary: Math.max(7, primaryFontSize),
-      secondary: Math.max(6, secondaryFontSize)
+      primary: Math.max(compactMode ? 6 : 7, primaryFontSize),
+      secondary: Math.max(compactMode ? 5.5 : 6, secondaryFontSize)
     };
   };
   
@@ -166,8 +168,8 @@ const PitchMapVisualization = ({
           y={scaledDimensions.padding.top}
           width={scaledDimensions.pitchWidth}
           height={scaledDimensions.pitchHeight}
-          fill="#f0fdf4"
-          stroke="#86efac"
+          fill={colors.neutral[50]}
+          stroke={colors.chart.green}
           strokeWidth={2}
           rx={4}
         />
@@ -190,10 +192,10 @@ const PitchMapVisualization = ({
         ))}
         
         {/* Stumps centered within full toss row */}
-        {!hideStumps && <StumpsIndicator dimensions={scaledDimensions} scale={scale} mode={mode} />}
+        {!hideStumps && <StumpsIndicator dimensions={scaledDimensions} scale={scale} mode={mode} compactMode={compactMode} />}
         
         {/* Axis labels */}
-        <AxisLabels dimensions={scaledDimensions} mode={mode} scale={scale} />
+        <AxisLabels dimensions={scaledDimensions} mode={mode} scale={scale} compactMode={compactMode} />
       </svg>
 
       {/* Legend */}
@@ -202,6 +204,7 @@ const PitchMapVisualization = ({
           metric={colorMetric}
           dataRange={dataRange}
           width={scaledDimensions.pitchWidth}
+          compactMode={compactMode}
         />
       )}
     </Box>
@@ -344,7 +347,7 @@ const CellContent = ({ x, y, width, height, cell, displayMetrics, secondaryMetri
           dominantBaseline="middle"
           fontSize={fontSizes.primary}
           fontWeight="600"
-          fill="#1f2937"
+          fill={colors.neutral[800]}
         >
           {primaryLine}
         </text>
@@ -358,7 +361,7 @@ const CellContent = ({ x, y, width, height, cell, displayMetrics, secondaryMetri
           textAnchor="middle"
           dominantBaseline="middle"
           fontSize={fontSizes.secondary}
-          fill="#4b5563"
+          fill={colors.neutral[600]}
         >
           {secondaryLine}
         </text>
@@ -370,9 +373,9 @@ const CellContent = ({ x, y, width, height, cell, displayMetrics, secondaryMetri
 /**
  * Axis labels for line and length
  */
-const AxisLabels = ({ dimensions, mode, scale }) => {
+const AxisLabels = ({ dimensions, mode, scale, compactMode }) => {
   const { padding, pitchWidth, pitchHeight } = dimensions;
-  const fontSize = 11 * scale;
+  const fontSize = Math.min(compactMode ? 9 : 11, 11 * scale);
   
   // Reverse length order to match cell positions (full toss at top near stumps, short at bottom)
   const reversedLengthOrder = [...LENGTH_ORDER].reverse();
@@ -391,7 +394,7 @@ const AxisLabels = ({ dimensions, mode, scale }) => {
               y={padding.top + pitchHeight + 18}
               textAnchor="middle"
               fontSize={fontSize}
-              fill="#6b7280"
+              fill={colors.neutral[600]}
             >
               {LINE_SHORT_LABELS[line]}
             </text>
@@ -412,7 +415,7 @@ const AxisLabels = ({ dimensions, mode, scale }) => {
               textAnchor="start"
               dominantBaseline="middle"
               fontSize={fontSize}
-              fill="#6b7280"
+              fill={colors.neutral[600]}
             >
               {LENGTH_SHORT_LABELS[length]}
             </text>
@@ -426,7 +429,7 @@ const AxisLabels = ({ dimensions, mode, scale }) => {
 /**
  * Stumps indicator centered within the full toss row
  */
-const StumpsIndicator = ({ dimensions, scale, mode }) => {
+const StumpsIndicator = ({ dimensions, scale, mode, compactMode }) => {
   const { padding, pitchWidth, pitchHeight, cellHeight, stumpHeight, stumpWidth, stumpGap } = dimensions;
   const stumpX = padding.left + pitchWidth / 2;
   
@@ -446,52 +449,56 @@ const StumpsIndicator = ({ dimensions, scale, mode }) => {
           key={offset}
           x={stumpX + offset * stumpGap - stumpWidth / 2}
           y={stumpTopY}
-          width={stumpWidth}
-          height={stumpHeight}
-          fill="#78350f"
-          rx={1}
-        />
-      ))}
-      {/* Bails on top of stumps */}
-      <rect
-        x={stumpX - stumpGap - stumpWidth}
-        y={stumpTopY - 5}
-        width={stumpGap * 2 + stumpWidth * 2}
-        height={6}
-        fill="#92400e"
-        rx={2}
+        width={stumpWidth}
+        height={stumpHeight}
+        fill={colors.warning[700]}
+        rx={1}
       />
-      {/* Batter label above stumps */}
+    ))}
+    {/* Bails on top of stumps */}
+    <rect
+      x={stumpX - stumpGap - stumpWidth}
+      y={stumpTopY - 5}
+      width={stumpGap * 2 + stumpWidth * 2}
+      height={6}
+      fill={colors.warning[600]}
+      rx={2}
+    />
+    {/* Batter label above stumps */}
+    {!compactMode && (
       <text
         x={stumpX}
         y={stumpTopY - 14}
         textAnchor="middle"
         fontSize={11 * scale}
         fontWeight="600"
-        fill="#78350f"
+        fill={colors.warning[700]}
       >
         🏏 Batter
       </text>
-      
-      {/* Bowler label at bottom */}
+    )}
+    
+    {/* Bowler label at bottom */}
+    {!compactMode && (
       <text
         x={stumpX}
         y={padding.top + pitchHeight + 38}
         textAnchor="middle"
         fontSize={11 * scale}
         fontWeight="500"
-        fill="#6b7280"
+        fill={colors.neutral[600]}
       >
         ↑ Bowler
       </text>
-    </g>
-  );
+    )}
+  </g>
+);
 };
 
 /**
  * Color scale legend (red=bad for batter, green=good for batter)
  */
-const ColorLegend = ({ metric, dataRange, width }) => {
+const ColorLegend = ({ metric, dataRange, width, compactMode }) => {
   const metricConfig = METRICS[metric];
   if (!metricConfig || !dataRange) return null;
   
@@ -502,8 +509,8 @@ const ColorLegend = ({ metric, dataRange, width }) => {
   const isDescending = metricConfig.colorScale === 'descending';
   
   return (
-    <Box sx={{ mt: 2, display: 'flex', flexDirection: 'column', alignItems: 'center' }}>
-      <Typography variant="caption" color="text.secondary" sx={{ mb: 0.5 }}>
+    <Box sx={{ mt: compactMode ? 1.5 : 2, display: 'flex', flexDirection: 'column', alignItems: 'center' }}>
+      <Typography variant="caption" color="text.secondary" sx={{ mb: 0.5, fontSize: compactMode ? '0.65rem' : undefined }}>
         Color: {metricConfig.label} {isDescending ? '(lower = better)' : '(higher = better)'}
       </Typography>
       <svg width={legendWidth} height={28}>
@@ -522,10 +529,10 @@ const ColorLegend = ({ metric, dataRange, width }) => {
           fill={`url(#${gradientId})`}
           rx={3}
         />
-        <text x={0} y={26} fontSize={10} fill="#6b7280">
+        <text x={0} y={26} fontSize={compactMode ? 9 : 10} fill={colors.neutral[600]}>
           {metricConfig.format(dataRange.min)}
         </text>
-        <text x={legendWidth} y={26} fontSize={10} fill="#6b7280" textAnchor="end">
+        <text x={legendWidth} y={26} fontSize={compactMode ? 9 : 10} fill={colors.neutral[600]} textAnchor="end">
           {metricConfig.format(dataRange.max)}
         </text>
       </svg>

--- a/src/components/PitchMap/pitchMapConstants.js
+++ b/src/components/PitchMap/pitchMapConstants.js
@@ -5,6 +5,8 @@
  * Mobile-first design with stumps centered in full toss row.
  */
 
+import { colors } from '../../theme/designSystem';
+
 // Line values from delivery_details (left to right from bowler's view for RHB)
 export const LINE_ORDER = [
   'WIDE_OUTSIDE_OFFSTUMP',
@@ -157,10 +159,10 @@ export const DEFAULT_COLOR_METRIC = 'strike_rate';
 
 // Heat map color scale (red=bad for batter, green=good for batter)
 export const HEAT_COLORS = {
-  bad: '#ef4444',
-  neutral: '#fbbf24',
-  good: '#22c55e',
-  noData: '#e5e7eb'
+  bad: colors.chart.red,
+  neutral: colors.chart.yellow,
+  good: colors.chart.green,
+  noData: colors.neutral[200]
 };
 
 // Minimum balls threshold options

--- a/src/components/PlayerPitchMap.jsx
+++ b/src/components/PlayerPitchMap.jsx
@@ -17,6 +17,7 @@ import Card from './ui/Card';
 import FilterBar from './ui/FilterBar';
 import { PitchMapVisualization } from './PitchMap';
 import config from '../config';
+import { colors as designColors } from '../theme/designSystem';
 
 const PlayerPitchMap = ({
   playerName,
@@ -27,13 +28,20 @@ const PlayerPitchMap = ({
   includeInternational = false,
   topTeams = null,
   isMobile = false,
-  wrapInCard = true
+  wrapInCard = true,
+  shareView = false
 }) => {
   const [pitchData, setPitchData] = useState(null);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState(null);
+  const isCompact = shareView || isMobile;
   const Wrapper = wrapInCard ? Card : Box;
-  const wrapperProps = wrapInCard ? { isMobile } : { sx: { width: '100%' } };
+  const frameSx = isMobile
+    ? { minHeight: 420, aspectRatio: '4 / 5' }
+    : {};
+  const wrapperProps = wrapInCard
+    ? { isMobile, shareFrame: shareView, sx: frameSx }
+    : { sx: { width: '100%', ...frameSx } };
 
   // Filters
   const [phase, setPhase] = useState('overall');
@@ -219,7 +227,7 @@ const PlayerPitchMap = ({
         gap: 1,
         flexWrap: isMobile ? 'wrap' : 'nowrap'
       }}>
-        <Typography variant={isMobile ? "h6" : "h5"} sx={{ fontWeight: 600, flexShrink: 0 }}>
+        <Typography variant={isCompact ? "h6" : "h5"} sx={{ fontWeight: 600, flexShrink: 0 }}>
           Pitch Map
         </Typography>
         <Box sx={{ flexShrink: 1, minWidth: 0 }}>
@@ -227,18 +235,18 @@ const PlayerPitchMap = ({
             filters={filterConfig}
             activeFilters={{ phase, bowlKind, line, length, shot }}
             onFilterChange={handleFilterChange}
-            isMobile={isMobile}
+            isMobile={isCompact}
           />
         </Box>
       </Box>
 
       {/* Stats Summary */}
-      <Box sx={{ display: 'flex', gap: isMobile ? 0.5 : 1, mb: isMobile ? 1.5 : 2, flexWrap: 'wrap', justifyContent: 'center' }}>
-        <Chip label={`${pitchData.total_balls} balls`} size="small" color="primary" sx={{ fontSize: isMobile ? '0.7rem' : undefined, height: isMobile ? 24 : undefined }} />
+      <Box sx={{ display: 'flex', gap: isCompact ? 0.5 : 1, mb: isCompact ? 1.5 : 2, flexWrap: 'wrap', justifyContent: 'center' }}>
+        <Chip label={`${pitchData.total_balls} balls`} size="small" sx={{ bgcolor: designColors.chart.blue, color: 'white', fontSize: isCompact ? '0.7rem' : undefined, height: isCompact ? 24 : undefined }} />
       </Box>
 
       {/* Pitch Map Visualization */}
-      <Box sx={{ maxWidth: 420, mx: 'auto' }}>
+      <Box sx={{ maxWidth: isCompact ? 360 : 420, mx: 'auto', width: '100%' }}>
         <PitchMapVisualization
           cells={pitchData.cells}
           mode="grid"
@@ -250,6 +258,7 @@ const PlayerPitchMap = ({
           subtitle={`${phase === 'overall' ? 'All Phases' : phase} ${bowlKind !== 'all' ? `• ${bowlKind}` : ''}`}
           hideStumps={true}
           hideLegend={true}
+          compactMode={isCompact}
         />
       </Box>
     </Wrapper>

--- a/src/components/WagonWheel.jsx
+++ b/src/components/WagonWheel.jsx
@@ -16,6 +16,7 @@ import {
 import Card from './ui/Card';
 import FilterBar from './ui/FilterBar';
 import config from '../config';
+import { colors as designColors } from '../theme/designSystem';
 
 
 const WagonWheel = ({
@@ -27,13 +28,20 @@ const WagonWheel = ({
   includeInternational = false,
   topTeams = null,
   isMobile = false,
-  wrapInCard = true
+  wrapInCard = true,
+  shareView = false
 }) => {
   const [wagonData, setWagonData] = useState(null);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState(null);
+  const isCompact = shareView || isMobile;
   const Wrapper = wrapInCard ? Card : Box;
-  const wrapperProps = wrapInCard ? { isMobile } : { sx: { width: '100%' } };
+  const frameSx = isMobile
+    ? { minHeight: 420, aspectRatio: '4 / 5' }
+    : {};
+  const wrapperProps = wrapInCard
+    ? { isMobile, shareFrame: shareView, sx: frameSx }
+    : { sx: { width: '100%', ...frameSx } };
 
   // Filters
   const [phase, setPhase] = useState('overall');
@@ -160,7 +168,7 @@ const WagonWheel = ({
     if (!wagonData || !stats) return null;
 
     // Responsive dimensions - circular field
-    const containerWidth = typeof window !== 'undefined' ? Math.min(window.innerWidth - (isMobile ? 48 : 80), 400) : 400;
+    const containerWidth = typeof window !== 'undefined' ? Math.min(window.innerWidth - (isCompact ? 48 : 80), 400) : 400;
     const width = containerWidth;
     const height = containerWidth; // Circular - same width and height
     const centerX = width / 2;
@@ -181,7 +189,7 @@ const WagonWheel = ({
           y1={centerY}
           x2={x2}
           y2={y2}
-          stroke="#e0e0e0"
+          stroke={designColors.neutral[200]}
           strokeWidth="1"
           strokeDasharray="4,4"
         />
@@ -211,19 +219,19 @@ const WagonWheel = ({
         }
 
         // Color by runs
-        let color = '#9e9e9e'; // dots
+        let color = designColors.neutral[400]; // dots
         let strokeWidth = 1;
         let opacity = 0.4;
         if (delivery.runs === 6) {
-          color = '#e91e63'; // sixes - pink
+          color = designColors.chart.pink; // sixes - pink
           strokeWidth = 2.5;
           opacity = 0.7;
         } else if (delivery.runs === 4) {
-          color = '#2196f3'; // fours - blue
+          color = designColors.chart.blue; // fours - blue
           strokeWidth = 2;
           opacity = 0.6;
         } else if (delivery.runs > 0) {
-          color = '#4caf50'; // runs - green
+          color = designColors.chart.green; // runs - green
           strokeWidth = 1.5;
           opacity = 0.5;
         }
@@ -250,8 +258,8 @@ const WagonWheel = ({
           cx={centerX}
           cy={centerY}
           r={maxRadius}
-          fill="#f5f5f5"
-          stroke="#bdbdbd"
+          fill={designColors.neutral[50]}
+          stroke={designColors.neutral[300]}
           strokeWidth="2"
         />
 
@@ -264,7 +272,7 @@ const WagonWheel = ({
           cy={centerY}
           r={maxRadius * 0.5}
           fill="none"
-          stroke="#e0e0e0"
+          stroke={designColors.neutral[200]}
           strokeWidth="1"
           strokeDasharray="4,4"
         />
@@ -275,8 +283,8 @@ const WagonWheel = ({
           y={centerY - (width * 0.075)}
           width={width * 0.025}
           height={width * 0.15}
-          fill="#d4a574"
-          stroke="#8d6e63"
+          fill={designColors.warning[50]}
+          stroke={designColors.warning[600]}
           strokeWidth="1"
         />
 
@@ -379,7 +387,7 @@ const WagonWheel = ({
         gap: 1,
         flexWrap: isMobile ? 'wrap' : 'nowrap'
       }}>
-        <Typography variant={isMobile ? "h6" : "h5"} sx={{ fontWeight: 600, flexShrink: 0 }}>
+        <Typography variant={isCompact ? "h6" : "h5"} sx={{ fontWeight: 600, flexShrink: 0 }}>
           Wagon Wheel
         </Typography>
         <Box sx={{ flexShrink: 1, minWidth: 0 }}>
@@ -387,38 +395,38 @@ const WagonWheel = ({
             filters={filterConfig}
             activeFilters={{ phase, bowlKind, line, length, shot }}
             onFilterChange={handleFilterChange}
-            isMobile={isMobile}
+            isMobile={isCompact}
             showActiveCount={false}
           />
         </Box>
       </Box>
 
       {/* Stats Summary */}
-      <Box sx={{ display: 'flex', gap: isMobile ? 0.5 : 1, mb: isMobile ? 1.5 : 2, flexWrap: 'wrap', justifyContent: 'center' }}>
-        <Chip label={`${stats.totalBalls} balls`} size="small" sx={{ fontSize: isMobile ? '0.7rem' : undefined, height: isMobile ? 24 : undefined }} />
-        <Chip label={`${stats.totalRuns} runs`} size="small" color="primary" sx={{ fontSize: isMobile ? '0.7rem' : undefined, height: isMobile ? 24 : undefined }} />
-        <Chip label={`SR: ${stats.strikeRate}`} size="small" sx={{ fontSize: isMobile ? '0.7rem' : undefined, height: isMobile ? 24 : undefined }} />
-        <Chip label={`${stats.fours} x 4s`} size="small" sx={{ bgcolor: '#2196f3', color: 'white', fontSize: isMobile ? '0.7rem' : undefined, height: isMobile ? 24 : undefined }} />
-        <Chip label={`${stats.sixes} x 6s`} size="small" sx={{ bgcolor: '#e91e63', color: 'white', fontSize: isMobile ? '0.7rem' : undefined, height: isMobile ? 24 : undefined }} />
+      <Box sx={{ display: 'flex', gap: isCompact ? 0.5 : 1, mb: isCompact ? 1.5 : 2, flexWrap: 'wrap', justifyContent: 'center' }}>
+        <Chip label={`${stats.totalBalls} balls`} size="small" sx={{ fontSize: isCompact ? '0.7rem' : undefined, height: isCompact ? 24 : undefined }} />
+        <Chip label={`${stats.totalRuns} runs`} size="small" sx={{ bgcolor: designColors.chart.blue, color: 'white', fontSize: isCompact ? '0.7rem' : undefined, height: isCompact ? 24 : undefined }} />
+        <Chip label={`SR: ${stats.strikeRate}`} size="small" sx={{ fontSize: isCompact ? '0.7rem' : undefined, height: isCompact ? 24 : undefined }} />
+        <Chip label={`${stats.fours} x 4s`} size="small" sx={{ bgcolor: designColors.chart.blue, color: 'white', fontSize: isCompact ? '0.7rem' : undefined, height: isCompact ? 24 : undefined }} />
+        <Chip label={`${stats.sixes} x 6s`} size="small" sx={{ bgcolor: designColors.chart.pink, color: 'white', fontSize: isCompact ? '0.7rem' : undefined, height: isCompact ? 24 : undefined }} />
       </Box>
 
       {/* Legend */}
-      <Box sx={{ display: 'flex', gap: isMobile ? 1.5 : 2, mb: isMobile ? 1.5 : 2, flexWrap: 'wrap', justifyContent: 'center', fontSize: isMobile ? '0.7rem' : '0.875rem' }}>
+      <Box sx={{ display: 'flex', gap: isCompact ? 1.5 : 2, mb: isCompact ? 1.5 : 2, flexWrap: 'wrap', justifyContent: 'center', fontSize: isCompact ? '0.65rem' : '0.875rem' }}>
         <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
-          <Box sx={{ width: isMobile ? 10 : 12, height: isMobile ? 10 : 12, borderRadius: '50%', bgcolor: '#e91e63' }} />
-          <Typography variant="caption" sx={{ fontSize: isMobile ? '0.7rem' : undefined }}>Sixes</Typography>
+          <Box sx={{ width: isCompact ? 10 : 12, height: isCompact ? 10 : 12, borderRadius: '50%', bgcolor: designColors.chart.pink }} />
+          <Typography variant="caption" sx={{ fontSize: isCompact ? '0.65rem' : undefined }}>Sixes</Typography>
         </Box>
         <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
-          <Box sx={{ width: isMobile ? 8 : 10, height: isMobile ? 8 : 10, borderRadius: '50%', bgcolor: '#2196f3' }} />
-          <Typography variant="caption" sx={{ fontSize: isMobile ? '0.7rem' : undefined }}>Fours</Typography>
+          <Box sx={{ width: isCompact ? 8 : 10, height: isCompact ? 8 : 10, borderRadius: '50%', bgcolor: designColors.chart.blue }} />
+          <Typography variant="caption" sx={{ fontSize: isCompact ? '0.65rem' : undefined }}>Fours</Typography>
         </Box>
         <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
-          <Box sx={{ width: isMobile ? 7 : 8, height: isMobile ? 7 : 8, borderRadius: '50%', bgcolor: '#4caf50' }} />
-          <Typography variant="caption" sx={{ fontSize: isMobile ? '0.7rem' : undefined }}>Runs</Typography>
+          <Box sx={{ width: isCompact ? 7 : 8, height: isCompact ? 7 : 8, borderRadius: '50%', bgcolor: designColors.chart.green }} />
+          <Typography variant="caption" sx={{ fontSize: isCompact ? '0.65rem' : undefined }}>Runs</Typography>
         </Box>
         <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
-          <Box sx={{ width: isMobile ? 5 : 6, height: isMobile ? 5 : 6, borderRadius: '50%', bgcolor: '#9e9e9e' }} />
-          <Typography variant="caption" sx={{ fontSize: isMobile ? '0.7rem' : undefined }}>Dots</Typography>
+          <Box sx={{ width: isCompact ? 5 : 6, height: isCompact ? 5 : 6, borderRadius: '50%', bgcolor: designColors.neutral[400] }} />
+          <Typography variant="caption" sx={{ fontSize: isCompact ? '0.65rem' : undefined }}>Dots</Typography>
         </Box>
       </Box>
 

--- a/src/components/ui/Card.jsx
+++ b/src/components/ui/Card.jsx
@@ -10,9 +10,32 @@ const Card = ({
   isMobile = false,
   hover = false,
   noPadding = false,
+  shareFrame = false,
+  shareFrameLabel = 'Cricket Data Thing',
   sx = {},
   ...props
 }) => {
+  const shareFrameStyles = shareFrame
+    ? {
+        background: `linear-gradient(135deg, ${colors.neutral[0]} 0%, ${colors.neutral[50]} 100%)`,
+        borderColor: colors.neutral[200],
+        position: 'relative',
+        overflow: 'hidden',
+        '&::after': {
+          content: `"${shareFrameLabel}"`,
+          position: 'absolute',
+          bottom: 8,
+          right: 12,
+          fontSize: '0.65rem',
+          color: colors.neutral[400],
+          letterSpacing: '0.08em',
+          textTransform: 'uppercase',
+          opacity: 0.6,
+          pointerEvents: 'none',
+        },
+      }
+    : {};
+
   return (
     <Box
       sx={{
@@ -33,6 +56,7 @@ const Card = ({
             transform: 'translateY(-2px)',
           },
         }),
+        ...shareFrameStyles,
         ...sx,
       }}
       {...props}


### PR DESCRIPTION
### Motivation
- Provide a consistent mobile-friendly visual size and aspect for chart cards to make screenshots/share images reliable. 
- Offer an optional “share framing” decoration (subtle background and watermark) for exportable/embedded visuals. 
- Ensure all charts use the design system color tokens instead of hardcoded hex values for consistent branding. 
- Prevent label and legend overflow on small screens by adding a compact/ShareView mode for chart components. 

### Description
- Added a `shareFrame`/`shareFrameLabel` prop to `Card` to enable optional background framing and watermark text. 
- Introduced `shareView`/`compactMode` props on `InningsScatter`, `WagonWheel`, `PlayerPitchMap`, and `PitchMapVisualization` and added responsive `minHeight`/`aspectRatio` wrappers to standardize mobile sizing. 
- Replaced hardcoded chart colors with the design system palette (e.g., `colors.chart.*`, `colors.neutral.*`) and updated heatmap constants to reference `designSystem` colors. 
- Tuned responsive behavior: smaller tick and font sizes, adjusted reference line strokes, and conditional legend/stump labels in compact mode to avoid overflow. 

### Testing
- Started the dev server with `npm start`; the app compiled and the dev server ran (webpack emitted warnings but started). 
- Captured a mobile-render screenshot using an automated Playwright script which completed and produced `artifacts/mobile-visualization.png`. 
- Changes were staged and committed locally as part of this PR.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6959f9db36c8832cbbc2a9bb93ebab2a)