### PR TITLE
Refactor player profile filters for shared config and mobile apply

### DIFF
--- a/src/components/playerProfile/FilterBar.jsx
+++ b/src/components/playerProfile/FilterBar.jsx
@@ -1,0 +1,136 @@
+import React from 'react';
+import { Box, Button, TextField, Autocomplete } from '@mui/material';
+import CompetitionFilter from '../CompetitionFilter';
+import { borderRadius, colors, spacing, typography } from '../../theme/designSystem';
+
+const FilterBar = ({
+  filters,
+  values,
+  onChange,
+  onSubmit,
+  loading,
+  competitionFilters,
+  onCompetitionChange,
+}) => {
+  const dateFilters = filters.filter((filter) => filter.group === 'dateRange');
+
+  const inputStyles = {
+    '& .MuiInputBase-root': {
+      borderRadius: `${borderRadius.base}px`,
+      backgroundColor: colors.neutral[0],
+    },
+    '& .MuiOutlinedInput-notchedOutline': {
+      borderColor: colors.neutral[300],
+    },
+    '&:hover .MuiOutlinedInput-notchedOutline': {
+      borderColor: colors.primary[400],
+    },
+    '&.Mui-focused .MuiOutlinedInput-notchedOutline': {
+      borderColor: colors.primary[600],
+    },
+  };
+
+  const renderFilterField = (filter) => {
+    if (filter.type === 'autocomplete') {
+      return (
+        <Autocomplete
+          key={filter.key}
+          value={values[filter.key]}
+          onChange={(_, newValue) => onChange(filter.key, newValue)}
+          options={filter.options}
+          fullWidth
+          size="small"
+          getOptionLabel={(option) => {
+            if (typeof option === 'string') {
+              return option;
+            }
+            return option || '';
+          }}
+          isOptionEqualToValue={(option, value) => {
+            if (typeof value === 'string') {
+              return option === value;
+            }
+            return option === value;
+          }}
+          renderInput={(params) => (
+            <TextField
+              {...params}
+              label={filter.label}
+              required={filter.required}
+              variant="outlined"
+              sx={inputStyles}
+            />
+          )}
+        />
+      );
+    }
+
+    return (
+      <TextField
+        key={filter.key}
+        label={filter.label}
+        type="date"
+        value={values[filter.key]}
+        onChange={(event) => onChange(filter.key, event.target.value)}
+        InputLabelProps={{ shrink: true }}
+        size="small"
+        sx={inputStyles}
+      />
+    );
+  };
+
+  return (
+    <Box sx={{ display: 'flex', flexDirection: 'column', gap: `${spacing.base}px` }}>
+      {filters.reduce(
+        (acc, filter) => {
+          if (filter.group === 'dateRange') {
+            if (!acc.hasDateRange) {
+              acc.items.push(
+                <Box
+                  key="date-range"
+                  sx={{
+                    display: 'grid',
+                    gridTemplateColumns: 'repeat(2, minmax(0, 1fr))',
+                    gap: `${spacing.sm}px`,
+                  }}
+                >
+                  {dateFilters.map((dateFilter) => renderFilterField(dateFilter))}
+                </Box>
+              );
+              acc.hasDateRange = true;
+            }
+            return acc;
+          }
+
+          acc.items.push(renderFilterField(filter));
+          return acc;
+        },
+        { items: [], hasDateRange: false }
+      ).items}
+
+      <Button
+        variant="contained"
+        onClick={onSubmit}
+        disabled={!values.player || loading}
+        id="go-button"
+        fullWidth
+        size="medium"
+        sx={{
+          borderRadius: `${borderRadius.base}px`,
+          textTransform: 'none',
+          fontWeight: typography.fontWeight.semibold,
+        }}
+      >
+        GO
+      </Button>
+
+      <CompetitionFilter
+        onFilterChange={onCompetitionChange}
+        isMobile={false}
+        value={competitionFilters}
+      />
+    </Box>
+  );
+};
+
+export default FilterBar;

--- a/src/components/playerProfile/FilterSheet.jsx
+++ b/src/components/playerProfile/FilterSheet.jsx
@@ -1,0 +1,159 @@
+import React, { useEffect, useState } from 'react';
+import { Box, Button, TextField, Autocomplete } from '@mui/material';
+import CompetitionFilter from '../CompetitionFilter';
+import FilterDrawer from '../ui/FilterDrawer';
+import { borderRadius, colors, spacing, typography } from '../../theme/designSystem';
+
+const touchTargetStyles = {
+  '& .MuiInputBase-root': {
+    minHeight: 44,
+    borderRadius: `${borderRadius.base}px`,
+    backgroundColor: colors.neutral[0],
+  },
+  '& .MuiOutlinedInput-notchedOutline': {
+    borderColor: colors.neutral[300],
+  },
+  '&:hover .MuiOutlinedInput-notchedOutline': {
+    borderColor: colors.primary[400],
+  },
+  '&.Mui-focused .MuiOutlinedInput-notchedOutline': {
+    borderColor: colors.primary[600],
+  },
+};
+
+const FilterSheet = ({
+  open,
+  onClose,
+  filters,
+  values,
+  competitionFilters,
+  onApply,
+  loading,
+}) => {
+  const [draftValues, setDraftValues] = useState(values);
+  const [draftCompetitionFilters, setDraftCompetitionFilters] = useState(competitionFilters);
+
+  useEffect(() => {
+    if (open) {
+      setDraftValues(values);
+      setDraftCompetitionFilters(competitionFilters);
+    }
+  }, [open, values, competitionFilters]);
+
+  const handleChange = (key, value) => {
+    setDraftValues((prev) => ({ ...prev, [key]: value }));
+  };
+
+  const handleApply = () => {
+    onApply(draftValues, draftCompetitionFilters);
+    onClose();
+  };
+
+  const dateFilters = filters.filter((filter) => filter.group === 'dateRange');
+
+  const renderFilterField = (filter) => {
+    if (filter.type === 'autocomplete') {
+      return (
+        <Autocomplete
+          key={filter.key}
+          value={draftValues[filter.key]}
+          onChange={(_, newValue) => handleChange(filter.key, newValue)}
+          options={filter.options}
+          fullWidth
+          size="medium"
+          getOptionLabel={(option) => {
+            if (typeof option === 'string') {
+              return option;
+            }
+            return option || '';
+          }}
+          isOptionEqualToValue={(option, value) => {
+            if (typeof value === 'string') {
+              return option === value;
+            }
+            return option === value;
+          }}
+          renderInput={(params) => (
+            <TextField
+              {...params}
+              label={filter.label}
+              required={filter.required}
+              variant="outlined"
+              sx={touchTargetStyles}
+            />
+          )}
+        />
+      );
+    }
+
+    return (
+      <TextField
+        key={filter.key}
+        label={filter.label}
+        type="date"
+        value={draftValues[filter.key]}
+        onChange={(event) => handleChange(filter.key, event.target.value)}
+        InputLabelProps={{ shrink: true }}
+        fullWidth
+        size="medium"
+        sx={touchTargetStyles}
+      />
+    );
+  };
+
+  return (
+    <FilterDrawer
+      open={open}
+      onClose={onClose}
+      title="Filters"
+      footer={
+        <Button
+          fullWidth
+          variant="contained"
+          onClick={handleApply}
+          disabled={!draftValues.player || loading}
+          sx={{
+            borderRadius: `${borderRadius.base}px`,
+            textTransform: 'none',
+            fontWeight: typography.fontWeight.semibold,
+          }}
+        >
+          Apply Filters
+        </Button>
+      }
+    >
+      <Box sx={{ display: 'flex', flexDirection: 'column', gap: `${spacing.base}px` }}>
+        {filters.reduce(
+          (acc, filter) => {
+            if (filter.group === 'dateRange') {
+              if (!acc.hasDateRange) {
+                acc.items.push(
+                  <Box
+                    key="date-range"
+                    sx={{ display: 'flex', flexDirection: 'column', gap: `${spacing.base}px` }}
+                  >
+                    {dateFilters.map((dateFilter) => renderFilterField(dateFilter))}
+                  </Box>
+                );
+                acc.hasDateRange = true;
+              }
+              return acc;
+            }
+
+            acc.items.push(renderFilterField(filter));
+            return acc;
+          },
+          { items: [], hasDateRange: false }
+        ).items}
+
+        <CompetitionFilter
+          onFilterChange={setDraftCompetitionFilters}
+          isMobile
+          value={draftCompetitionFilters}
+        />
+      </Box>
+    </FilterDrawer>
+  );
+};
+
+export default FilterSheet;

--- a/src/components/playerProfile/filterConfig.js
+++ b/src/components/playerProfile/filterConfig.js
@@ -1,0 +1,34 @@
+export const DEFAULT_START_DATE = '2020-01-01';
+export const TODAY = new Date().toISOString().split('T')[0];
+
+export const buildPlayerProfileFilters = ({ players, venues }) => [
+  {
+    key: 'player',
+    label: 'Select Player',
+    type: 'autocomplete',
+    options: players,
+    defaultValue: null,
+    required: true,
+  },
+  {
+    key: 'startDate',
+    label: 'Start Date',
+    type: 'date',
+    defaultValue: DEFAULT_START_DATE,
+    group: 'dateRange',
+  },
+  {
+    key: 'endDate',
+    label: 'End Date',
+    type: 'date',
+    defaultValue: TODAY,
+    group: 'dateRange',
+  },
+  {
+    key: 'venue',
+    label: 'Select Venue',
+    type: 'autocomplete',
+    options: venues,
+    defaultValue: 'All Venues',
+  },
+];


### PR DESCRIPTION
### Motivation
- Centralize player profile filter definitions so desktop and mobile UIs share the same configuration and defaults.
- Replace duplicated inline filter markup with reusable components to ensure consistent spacing, styling and behavior.
- Provide a mobile-friendly filter sheet with 44px touch targets and an explicit “Apply Filters” action to reduce auto-fetch churn.
- Make `CompetitionFilter` controllable so the competition state can be kept in sync with the shared filter state.

### Description
- Added `src/components/playerProfile/filterConfig.js` and builder `buildPlayerProfileFilters` and constants `DEFAULT_START_DATE`/`TODAY` for filter definitions.
- Implemented a desktop `FilterBar` component (`src/components/playerProfile/FilterBar.jsx`) and a mobile `FilterSheet` component (`src/components/playerProfile/FilterSheet.jsx`) that consume the shared config and render consistent fields.
- Updated `PlayerProfile.jsx` to use the new `FilterBar` and `FilterSheet`, added `filterConfig`/`filterValues` memos, and implemented `handleFilterChange` and `handleApplyFilters` to coordinate state and trigger fetches only when appropriate.
- Refactored `CompetitionFilter.jsx` to accept a controlled `value` prop, initialize/resync from remote competition data, and emit resolved filters to the parent.

### Testing
- Launched the dev server with `npm start`, the app compiled and served the `/player` page (HTTP 200) though with ESLint warnings; the server started successfully.
- Captured a UI screenshot by visiting `/player` using a Playwright script to verify the new desktop/mobile filter UI rendering; the screenshot artifact was produced.
- No unit or integration test suites were executed as part of this change.
- All manual automated steps above completed successfully (server started, page returned, screenshot saved).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6959fcf3405c832cbcea76c5e950442b)