### PR TITLE
Add profile loading skeleton, chart empty states, and standardized alert banner

### DIFF
--- a/src/components/BallRunDistribution.jsx
+++ b/src/components/BallRunDistribution.jsx
@@ -13,6 +13,7 @@ import {
 } from 'recharts';
 import _ from 'lodash';
 import Card from './ui/Card';
+import { EmptyState } from './ui';
 
 const BallRunDistribution = ({ innings, isMobile: isMobileProp, wrapInCard = true }) => {
   const theme = useTheme();
@@ -20,6 +21,22 @@ const BallRunDistribution = ({ innings, isMobile: isMobileProp, wrapInCard = tru
   const isMobile = isMobileProp !== undefined ? isMobileProp : isMobileDetected;
   const Wrapper = wrapInCard ? Card : Box;
   const wrapperProps = wrapInCard ? { isMobile } : { sx: { width: '100%' } };
+
+  if (!innings?.length) {
+    return (
+      <Wrapper {...wrapperProps}>
+        <Typography variant={isMobile ? "h6" : "h5"} sx={{ fontWeight: 600, mb: 2 }}>
+          Inning Distribution
+        </Typography>
+        <EmptyState
+          title="No innings match these filters"
+          description="Adjust the filters to populate the distribution."
+          isMobile={isMobile}
+          minHeight={isMobile ? 300 : 360}
+        />
+      </Wrapper>
+    );
+  }
 
   const processData = () => {
     const ballRanges = {};

--- a/src/components/BowlingMatchupMatrix.jsx
+++ b/src/components/BowlingMatchupMatrix.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { Typography, Box, Tooltip, useMediaQuery, useTheme } from '@mui/material';
 import { Info as InfoIcon } from 'lucide-react';
 import Card from './ui/Card';
+import { EmptyState } from './ui';
 
 const MetricCell = ({ stats, isMobile }) => {
   if (!stats || !stats.runs) return <td style={{ textAlign: 'center', padding: '8px' }}>-</td>;
@@ -65,9 +66,12 @@ const BowlingMatchupMatrix = ({ stats, isMobile: isMobileProp, wrapInCard = true
             <InfoIcon size={isMobile ? 14 : 16} />
           </Tooltip>
         </Box>
-        <Typography variant="body2" color="text.secondary">
-          Bowling matchup data not available
-        </Typography>
+        <EmptyState
+          title="No innings match these filters"
+          description="Bowling matchup data is unavailable for the selected filters."
+          isMobile={isMobile}
+          minHeight={isMobile ? 220 : 260}
+        />
       </Wrapper>
     );
   }

--- a/src/components/ContributionGraph.jsx
+++ b/src/components/ContributionGraph.jsx
@@ -1,5 +1,6 @@
 import React, { useMemo } from 'react';
 import { Box, Typography } from '@mui/material';
+import { EmptyState } from './ui';
 import { borderRadius, colors, spacing, typography } from '../theme/designSystem';
 import { getBatterColor, getWeekStart } from './contributionGraphUtils';
 
@@ -90,7 +91,12 @@ const ContributionGraph = ({ innings, playerName }) => {
   }, [innings]);
 
   if (!innings || innings.length === 0) {
-    return null;
+    return (
+      <EmptyState
+        title="No innings match these filters"
+        description="Try adjusting the date range or venue to see more innings."
+      />
+    );
   }
 
   // Determine label format based on time span

--- a/src/components/InningsScatter.jsx
+++ b/src/components/InningsScatter.jsx
@@ -12,6 +12,7 @@ import {
 } from 'recharts';
 import Card from './ui/Card';
 import FilterBar from './ui/FilterBar';
+import { EmptyState } from './ui';
 import { colors as designColors } from '../theme/designSystem';
 
 const InningsScatter = ({ innings, wrapInCard = true, shareView = false }) => {
@@ -133,6 +134,22 @@ const InningsScatter = ({ innings, wrapInCard = true, shareView = false }) => {
     if (key === 'xAxis') setXMetric(value);
     else if (key === 'yAxis') setYMetric(value);
   };
+
+  if (!innings?.length) {
+    return (
+      <Wrapper {...wrapperProps}>
+        <Typography variant={isCompact ? "h6" : "h5"} sx={{ fontWeight: 600, mb: isCompact ? 1.5 : 2 }}>
+          Balls Faced vs Runs
+        </Typography>
+        <EmptyState
+          title="No innings match these filters"
+          description="Try adjusting the filters to explore other innings."
+          isMobile={isCompact}
+          minHeight={chartHeight}
+        />
+      </Wrapper>
+    );
+  }
 
   return (
     <Wrapper {...wrapperProps}>

--- a/src/components/PlayerDNASummary.jsx
+++ b/src/components/PlayerDNASummary.jsx
@@ -1,9 +1,10 @@
 import React, { useState, useEffect } from 'react';
-import { Box, Card, CardContent, Typography, CircularProgress, Alert } from '@mui/material';
+import { Box, Card, CardContent, Typography, CircularProgress } from '@mui/material';
 import { Bolt as BoltIcon } from '@mui/icons-material';
 import axios from 'axios';
 import { spacing } from '../theme/designSystem';
 import config from '../config';
+import { AlertBanner } from './ui';
 
 const PlayerDNASummary = ({ 
   playerName, 
@@ -103,9 +104,9 @@ const PlayerDNASummary = ({
 
           {/* Error State */}
           {error && !loading && (
-            <Alert severity="error" sx={{ py: `${spacing.xs}px` }}>
+            <AlertBanner severity="error" sx={{ py: `${spacing.xs}px` }}>
               <Typography variant="body2">{error}</Typography>
-            </Alert>
+            </AlertBanner>
           )}
 
           {/* Summary Items */}

--- a/src/components/PlayerPitchMap.jsx
+++ b/src/components/PlayerPitchMap.jsx
@@ -10,11 +10,11 @@ import {
   Box,
   Typography,
   CircularProgress,
-  Alert,
   Chip
 } from '@mui/material';
 import Card from './ui/Card';
 import FilterBar from './ui/FilterBar';
+import { AlertBanner, EmptyState } from './ui';
 import { PitchMapVisualization } from './PitchMap';
 import config from '../config';
 import { colors as designColors } from '../theme/designSystem';
@@ -126,26 +126,33 @@ const PlayerPitchMap = ({
 
   if (loading) {
     return (
-      <Box sx={{ textAlign: 'center', py: 3 }}>
-        <CircularProgress />
-        <Typography sx={{ mt: 2 }}>Loading pitch map data...</Typography>
-      </Box>
+      <Wrapper {...wrapperProps}>
+        <Box sx={{ textAlign: 'center', py: 3 }}>
+          <CircularProgress />
+          <Typography sx={{ mt: 2 }}>Loading pitch map data...</Typography>
+        </Box>
+      </Wrapper>
     );
   }
 
   if (error) {
     return (
-      <Box sx={{ py: 2 }}>
-        <Alert severity="error">{error}</Alert>
-      </Box>
+      <Wrapper {...wrapperProps}>
+        <AlertBanner severity="error">{error}</AlertBanner>
+      </Wrapper>
     );
   }
 
   if (!pitchData || pitchData.total_balls === 0) {
     return (
-      <Box sx={{ py: 2 }}>
-        <Alert severity="info">No pitch map data available for the selected filters.</Alert>
-      </Box>
+      <Wrapper {...wrapperProps}>
+        <EmptyState
+          title="No innings match these filters"
+          description="No pitch map data is available for the selected filters."
+          isMobile={isCompact}
+          minHeight={isCompact ? 280 : 320}
+        />
+      </Wrapper>
     );
   }
 

--- a/src/components/PlayerProfile.jsx
+++ b/src/components/PlayerProfile.jsx
@@ -4,8 +4,6 @@ import {
   Box,
   Button,
   Typography,
-  CircularProgress,
-  Alert,
   useMediaQuery,
   useTheme,
   Chip,
@@ -28,11 +26,12 @@ import config from '../config';
 import PlayerDNASummary from './PlayerDNASummary';
 import WagonWheel from './WagonWheel';
 import PlayerPitchMap from './PlayerPitchMap';
-import { MobileStickyHeader, Section, VisualizationCard } from './ui';
+import { AlertBanner, MobileStickyHeader, Section, VisualizationCard } from './ui';
 import { colors, spacing, typography, borderRadius, zIndex } from '../theme/designSystem';
 import FilterBar from './playerProfile/FilterBar';
 import FilterSheet from './playerProfile/FilterSheet';
 import { buildPlayerProfileFilters, DEFAULT_START_DATE, TODAY } from './playerProfile/filterConfig';
+import PlayerProfileLoadingState from './playerProfile/PlayerProfileLoadingState';
 
 const PlayerProfile = () => {
   const location = useLocation();
@@ -357,7 +356,11 @@ const PlayerProfile = () => {
   return (
     <Container maxWidth="xl">
       <Box sx={{ py: isMobile ? 2 : 4 }}>
-        {error && <Alert severity="error" sx={{ mb: 2 }}>{error}</Alert>}
+        {error && (
+          <AlertBanner severity="error" sx={{ mb: 2 }}>
+            {error}
+          </AlertBanner>
+        )}
 
         {isMobile && stats && (
           <MobileStickyHeader
@@ -434,11 +437,7 @@ const PlayerProfile = () => {
           )}
 
           <Box sx={{ flex: 1, minWidth: 0 }}>
-            {loading && (
-              <Box sx={{ display: 'flex', justifyContent: 'center', py: 4 }}>
-                <CircularProgress />
-              </Box>
-            )}
+            {loading && <PlayerProfileLoadingState isMobile={isMobile} />}
 
             {stats && !loading && (
               <Box sx={{ mt: isMobile ? 2 : 0 }}>

--- a/src/components/StrikeRateIntervals.jsx
+++ b/src/components/StrikeRateIntervals.jsx
@@ -12,6 +12,7 @@ import {
 } from 'recharts';
 import Card from './ui/Card';
 import FilterBar from './ui/FilterBar';
+import { EmptyState } from './ui';
 import { colors as designColors } from '../theme/designSystem';
 
 const StrikeRateIntervals = ({ ballStats = [], isMobile: isMobileProp, wrapInCard = true }) => {  // Add default empty array
@@ -56,7 +57,13 @@ const StrikeRateIntervals = ({ ballStats = [], isMobile: isMobileProp, wrapInCar
         <Typography variant={isMobile ? "h6" : "h5"} sx={{ fontWeight: 600, mb: 1 }}>
           Strike Rate Progression by Intervals
         </Typography>
-        <Typography variant="body1" sx={{ mt: 2 }}>No data available</Typography>
+        <EmptyState
+          title="No innings match these filters"
+          description="Try adjusting the filters to see strike rate intervals."
+          isMobile={isMobile}
+          minHeight={isMobile ? 280 : 320}
+          sx={{ mt: 1 }}
+        />
       </Wrapper>
     );
   }

--- a/src/components/StrikeRateProgression.jsx
+++ b/src/components/StrikeRateProgression.jsx
@@ -2,6 +2,7 @@ import { useState, useEffect } from 'react';
 import { LineChart, Line, XAxis, YAxis, CartesianGrid, Tooltip, Legend, ResponsiveContainer } from 'recharts';
 import { Typography, Box, useMediaQuery, useTheme } from '@mui/material';
 import Card from './ui/Card';
+import { EmptyState } from './ui';
 import { colors as designColors } from '../theme/designSystem';
 import config from '../config';
 
@@ -47,10 +48,26 @@ const StrikeRateProgression = ({ selectedPlayer, dateRange, selectedVenue, compe
     fetchData();
   }, [selectedPlayer, dateRange, selectedVenue, competitionFilters]); // Removed shouldFetch from dependencies
 
+  const chartHeight = isMobile ? 350 : 400;
+
+  if (!data.length) {
+    return (
+      <Wrapper {...wrapperProps}>
+        <Typography variant={isMobile ? "h6" : "h5"} sx={{ fontWeight: 600, mb: 2 }}>
+          nth Ball SR
+        </Typography>
+        <EmptyState
+          title="No innings match these filters"
+          description="Try widening the date range or removing filters to see strike rate trends."
+          isMobile={isMobile}
+          minHeight={chartHeight}
+        />
+      </Wrapper>
+    );
+  }
+
   const minSR = Math.max(0, Math.floor(Math.min(...data.map(d => d.strike_rate || 0)) * 0.9));
   const maxSR = Math.ceil(Math.max(...data.map(d => d.strike_rate || 0)) * 1.1);
-
-  const chartHeight = isMobile ? 350 : 400;
 
   return (
     <Wrapper {...wrapperProps}>

--- a/src/components/TopInnings.jsx
+++ b/src/components/TopInnings.jsx
@@ -11,6 +11,7 @@ import {
 } from '@mui/material';
 import Card from './ui/Card';
 import FilterBar from './ui/FilterBar';
+import { EmptyState } from './ui';
 import { spacing } from '../theme/designSystem';
 
 const TopInnings = ({ innings, count = 10, isMobile = false, wrapInCard = true }) => {
@@ -97,6 +98,14 @@ const TopInnings = ({ innings, count = 10, isMobile = false, wrapInCard = true }
         </Box>
       </Box>
 
+      {processedInnings.length === 0 ? (
+        <EmptyState
+          title="No innings match these filters"
+          description="Adjust filters or expand the date range to see innings."
+          isMobile={isMobile}
+          minHeight={isMobile ? 240 : 280}
+        />
+      ) : (
       <TableContainer>
         <Table size={isMobile ? "small" : "medium"} sx={{
           '& .MuiTableCell-root': {
@@ -202,6 +211,7 @@ const TopInnings = ({ innings, count = 10, isMobile = false, wrapInCard = true }
           </TableBody>
         </Table>
       </TableContainer>
+      )}
     </Wrapper>
   );
 };

--- a/src/components/WagonWheel.jsx
+++ b/src/components/WagonWheel.jsx
@@ -10,11 +10,11 @@ import {
   Box,
   Typography,
   CircularProgress,
-  Alert,
   Chip
 } from '@mui/material';
 import Card from './ui/Card';
 import FilterBar from './ui/FilterBar';
+import { AlertBanner, EmptyState } from './ui';
 import config from '../config';
 import { colors as designColors } from '../theme/designSystem';
 
@@ -299,26 +299,33 @@ const WagonWheel = ({
 
   if (loading) {
     return (
-      <Box sx={{ textAlign: 'center', py: 3 }}>
-        <CircularProgress />
-        <Typography sx={{ mt: 2 }}>Loading wagon wheel data...</Typography>
-      </Box>
+      <Wrapper {...wrapperProps}>
+        <Box sx={{ textAlign: 'center', py: 3 }}>
+          <CircularProgress />
+          <Typography sx={{ mt: 2 }}>Loading wagon wheel data...</Typography>
+        </Box>
+      </Wrapper>
     );
   }
 
   if (error) {
     return (
-      <Box sx={{ py: 2 }}>
-        <Alert severity="error">{error}</Alert>
-      </Box>
+      <Wrapper {...wrapperProps}>
+        <AlertBanner severity="error">{error}</AlertBanner>
+      </Wrapper>
     );
   }
 
   if (!wagonData || wagonData.total_deliveries === 0) {
     return (
-      <Box sx={{ py: 2 }}>
-        <Alert severity="info">No wagon wheel data available for the selected filters.</Alert>
-      </Box>
+      <Wrapper {...wrapperProps}>
+        <EmptyState
+          title="No innings match these filters"
+          description="No wagon wheel data is available for the selected filters."
+          isMobile={isCompact}
+          minHeight={isCompact ? 280 : 320}
+        />
+      </Wrapper>
     );
   }
 

--- a/src/components/playerProfile/PlayerProfileLoadingState.jsx
+++ b/src/components/playerProfile/PlayerProfileLoadingState.jsx
@@ -1,0 +1,72 @@
+import React from 'react';
+import { Box, Skeleton as MuiSkeleton } from '@mui/material';
+import { Card, Section, Skeleton, VisualizationCard } from '../ui';
+import { borderRadius, spacing } from '../../theme/designSystem';
+
+const PlayerProfileLoadingState = ({ isMobile = false }) => {
+  const chartHeight = isMobile ? 220 : 280;
+
+  const renderChartSkeleton = () => (
+    <MuiSkeleton
+      variant="rectangular"
+      height={chartHeight}
+      sx={{ borderRadius: `${borderRadius.base}px` }}
+    />
+  );
+
+  const renderVisualizationSkeleton = (title) => (
+    <VisualizationCard title={title} isMobile={isMobile}>
+      {renderChartSkeleton()}
+    </VisualizationCard>
+  );
+
+  return (
+    <Box sx={{ mt: isMobile ? 2 : 0 }}>
+      <Section title="Career Overview" isMobile={isMobile} columns="1fr" disableTopSpacing>
+        <Skeleton.Grid cols={4} rows={1} isMobile={isMobile} />
+
+        <Card isMobile={isMobile}>
+          <MuiSkeleton width="40%" height={24} sx={{ mb: `${spacing.sm}px` }} />
+          <MuiSkeleton width="90%" height={16} sx={{ mb: `${spacing.xs}px` }} />
+          <MuiSkeleton width="85%" height={16} sx={{ mb: `${spacing.xs}px` }} />
+          <MuiSkeleton width="70%" height={16} />
+        </Card>
+
+        {renderVisualizationSkeleton('Contribution Timeline')}
+      </Section>
+
+      <Section
+        title="Shot Analysis"
+        isMobile={isMobile}
+        columns={{ xs: '1fr', md: 'repeat(2, minmax(0, 1fr))' }}
+      >
+        {renderVisualizationSkeleton('Wagon Wheel')}
+        {renderVisualizationSkeleton('Pitch Map')}
+      </Section>
+
+      <Section
+        title="Performance Breakdown"
+        isMobile={isMobile}
+        columns={{ xs: '1fr', md: 'repeat(2, minmax(0, 1fr))' }}
+      >
+        {renderVisualizationSkeleton('Phase Radar')}
+        {renderVisualizationSkeleton('Pace vs Spin')}
+        {renderVisualizationSkeleton('Innings Scatter')}
+        {renderVisualizationSkeleton('Strike Rate Progression')}
+        {renderVisualizationSkeleton('Ball Run Distribution')}
+        {renderVisualizationSkeleton('SR Progression')}
+      </Section>
+
+      <Section
+        title="Performance Highlights"
+        isMobile={isMobile}
+        columns={{ xs: '1fr', lg: 'repeat(2, minmax(0, 1fr))' }}
+      >
+        {renderVisualizationSkeleton('Top Innings')}
+        {renderVisualizationSkeleton('Bowling Type Matchups')}
+      </Section>
+    </Box>
+  );
+};
+
+export default PlayerProfileLoadingState;

--- a/src/components/ui/AlertBanner.jsx
+++ b/src/components/ui/AlertBanner.jsx
@@ -1,0 +1,56 @@
+import React from 'react';
+import { Alert } from '@mui/material';
+import { alpha } from '@mui/material/styles';
+import { borderRadius, colors, spacing, typography } from '../../theme/designSystem';
+
+const severityTokens = {
+  error: {
+    base: colors.error[600],
+    background: colors.error[50],
+  },
+  warning: {
+    base: colors.warning[600],
+    background: colors.warning[50],
+  },
+  info: {
+    base: colors.primary[600],
+    background: colors.primary[50],
+  },
+  success: {
+    base: colors.success[600],
+    background: colors.success[50],
+  },
+};
+
+const AlertBanner = ({ severity = 'info', sx = {}, children, ...props }) => {
+  const tokens = severityTokens[severity] ?? severityTokens.info;
+
+  return (
+    <Alert
+      severity={severity}
+      variant="outlined"
+      sx={{
+        borderRadius: `${borderRadius.base}px`,
+        borderColor: alpha(tokens.base, 0.35),
+        backgroundColor: tokens.background,
+        color: colors.neutral[900],
+        px: `${spacing.base}px`,
+        py: `${spacing.sm}px`,
+        alignItems: 'center',
+        '.MuiAlert-icon': {
+          color: tokens.base,
+        },
+        '.MuiAlert-message': {
+          fontSize: typography.fontSize.sm,
+          color: colors.neutral[800],
+        },
+        ...sx,
+      }}
+      {...props}
+    >
+      {children}
+    </Alert>
+  );
+};
+
+export default AlertBanner;

--- a/src/components/ui/EmptyState.jsx
+++ b/src/components/ui/EmptyState.jsx
@@ -1,0 +1,43 @@
+import React from 'react';
+import { Box, Typography } from '@mui/material';
+import { borderRadius, colors, spacing, typography } from '../../theme/designSystem';
+
+const EmptyState = ({
+  title = 'No data available',
+  description,
+  isMobile = false,
+  minHeight = 220,
+  sx = {},
+}) => (
+  <Box
+    sx={{
+      minHeight,
+      borderRadius: `${borderRadius.base}px`,
+      border: `1px dashed ${colors.neutral[200]}`,
+      backgroundColor: colors.neutral[50],
+      px: `${spacing.lg}px`,
+      py: `${spacing.lg}px`,
+      display: 'flex',
+      flexDirection: 'column',
+      alignItems: 'center',
+      justifyContent: 'center',
+      textAlign: 'center',
+      gap: `${spacing.xs}px`,
+      ...sx,
+    }}
+  >
+    <Typography
+      variant={isMobile ? 'subtitle1' : 'h6'}
+      sx={{ fontWeight: typography.fontWeight.semibold, color: colors.neutral[800] }}
+    >
+      {title}
+    </Typography>
+    {description && (
+      <Typography variant="body2" sx={{ color: colors.neutral[600] }}>
+        {description}
+      </Typography>
+    )}
+  </Box>
+);
+
+export default EmptyState;

--- a/src/components/ui/index.js
+++ b/src/components/ui/index.js
@@ -1,4 +1,6 @@
 export { default as Card } from './Card';
+export { default as AlertBanner } from './AlertBanner';
+export { default as EmptyState } from './EmptyState';
 export { default as FilterDrawer } from './FilterDrawer';
 export { default as FilterBar } from './FilterBar';
 export { default as LayoutGrid } from './LayoutGrid';


### PR DESCRIPTION
### Motivation

- Provide a section-aware skeleton loading UI that matches the final `PlayerProfile` layout instead of a lone spinner.
- Surface clear empty states on charts and visualizations when filters return no innings so users understand why charts are blank.
- Standardize error banners across components using design tokens and a single MUI `Alert` wrapper for consistent styling.

### Description

- Added shared UI components: `src/components/ui/AlertBanner.jsx` and `src/components/ui/EmptyState.jsx`, and exported them via `src/components/ui/index.js`.
- Implemented a composite profile loading skeleton at `src/components/playerProfile/PlayerProfileLoadingState.jsx` and replaced the top-level `CircularProgress` in `PlayerProfile.jsx` with this skeleton.
- Replaced inline `Alert` usages with `AlertBanner` and added `EmptyState` fallbacks across several visualizations including `ContributionGraph`, `InningsScatter`, `StrikeRateProgression`, `BallRunDistribution`, `StrikeRateIntervals`, `TopInnings`, `BowlingMatchupMatrix`, `WagonWheel`, and `PlayerPitchMap` to show messages like "No innings match these filters".

### Testing

- Started the dev server with `npm start` and the app compiled and served the UI (build completed with ESLint warnings but no errors).
- Ran a Playwright script to navigate to `http://localhost:3000/player` and capture a screenshot which completed successfully and produced `artifacts/player-profile.png`.
- No unit tests were added or run as these are UI-only changes; interactive smoke checks above succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695a002c2d58832c887fbbeb59abffdd)