### PR TITLE
Improve PlayerProfile accessibility

### DIFF
--- a/src/components/BallRunDistribution.jsx
+++ b/src/components/BallRunDistribution.jsx
@@ -14,6 +14,7 @@ import {
 import _ from 'lodash';
 import Card from './ui/Card';
 import { EmptyState } from './ui';
+import { colors as designColors } from '../theme/designSystem';
 
 const BallRunDistribution = ({ innings, isMobile: isMobileProp, wrapInCard = true }) => {
   const theme = useTheme();
@@ -145,26 +146,26 @@ const BallRunDistribution = ({ innings, isMobile: isMobileProp, wrapInCard = tru
             <CartesianGrid strokeDasharray="3 3" />
             <XAxis
               type="number"
-              tick={{ fontSize: isMobile ? 10 : 12 }}
+              tick={{ fontSize: isMobile ? 10 : 12, fill: designColors.neutral[800] }}
             >
               <Label
                 value="Number of Innings"
                 position="bottom"
                 offset={isMobile ? 5 : 0}
-                style={{ fontSize: isMobile ? 11 : 12 }}
+                style={{ fontSize: isMobile ? 11 : 12, fill: designColors.neutral[800] }}
               />
             </XAxis>
             <YAxis
               dataKey="ballRange"
               type="category"
-              tick={{ fontSize: isMobile ? 10 : 12 }}
+              tick={{ fontSize: isMobile ? 10 : 12, fill: designColors.neutral[800] }}
             >
               <Label
                 value="Balls Faced"
                 angle={-90}
                 position="insideLeft"
                 offset={isMobile ? 5 : 15}
-                style={{ textAnchor: 'middle', fontSize: isMobile ? 11 : 12 }}
+                style={{ textAnchor: 'middle', fontSize: isMobile ? 11 : 12, fill: designColors.neutral[800] }}
               />
             </YAxis>
             <Tooltip content={<CustomTooltip />} />

--- a/src/components/CompetitionFilter.jsx
+++ b/src/components/CompetitionFilter.jsx
@@ -1,16 +1,33 @@
 import React, { useState, useEffect } from 'react';
-import { 
-  Box, 
-  TextField, 
-  Autocomplete, 
+import {
+  Box,
+  TextField,
+  Autocomplete,
   FormGroup,
   FormControlLabel,
   Checkbox,
   CircularProgress,
-  Alert 
+  Alert
 } from '@mui/material';
 import axios from 'axios';
 import config from '../config';
+import { colors } from '../theme/designSystem';
+
+const touchTargetStyles = {
+    '& .MuiInputBase-root': {
+        minHeight: 44,
+    },
+    '& .MuiOutlinedInput-notchedOutline': {
+        borderColor: colors.neutral[300],
+    },
+    '&:hover .MuiOutlinedInput-notchedOutline': {
+        borderColor: colors.primary[400],
+    },
+    '&.Mui-focused .MuiOutlinedInput-notchedOutline': {
+        borderColor: colors.primary[600],
+        borderWidth: 2,
+    },
+};
 
 const buildAllLeaguesOption = () => ({ label: 'All Leagues', value: 'all' });
 
@@ -110,6 +127,7 @@ const CompetitionFilter = ({ onFilterChange, isMobile, value }) => {
                     multiple
                     value={selectedLeagues}
                     onChange={handleAutocompleteChange}
+                    size="medium"
                     options={[
                         {
                             label: 'All Leagues',
@@ -120,11 +138,12 @@ const CompetitionFilter = ({ onFilterChange, isMobile, value }) => {
                     getOptionLabel={(option) => option.label}
                     isOptionEqualToValue={(option, value) => option.value === value.value}
                     renderInput={(params) => (
-                        <TextField {...params} label="Select Leagues" />
+                        <TextField {...params} label="Select Leagues" sx={touchTargetStyles} />
                     )}
                     sx={{ width: isMobile ? '100%' : 400, mb: isMobile ? 1 : 0, mr: isMobile ? 0 : 2 }}
                 />
                 <FormControlLabel
+                    sx={{ minHeight: 44 }}
                     control={
                         <Checkbox
                             checked={includeInternational}
@@ -132,6 +151,13 @@ const CompetitionFilter = ({ onFilterChange, isMobile, value }) => {
                                 const newValue = e.target.checked;
                                 setIncludeInternational(newValue);
                                 handleSelectionChange(selectedLeagues, newValue, topTeams);
+                            }}
+                            sx={{
+                                p: 1.5,
+                                '&:focus-visible': {
+                                    outline: `2px solid ${colors.primary[600]}`,
+                                    outlineOffset: 2,
+                                },
                             }}
                         />
                     }
@@ -149,8 +175,12 @@ const CompetitionFilter = ({ onFilterChange, isMobile, value }) => {
                                 handleSelectionChange(selectedLeagues, includeInternational, newValue);
                             }}
                             inputProps={{ min: 1, max: 20 }}
-                            sx={{ width: isMobile ? '100%' : 100 }}
+                            sx={{
+                                width: isMobile ? '100%' : 100,
+                                ...touchTargetStyles,
+                            }}
                             fullWidth={isMobile}
+                            size="medium"
                         />
                     </Box>
                 )}

--- a/src/components/ContextualQueryPrompts.jsx
+++ b/src/components/ContextualQueryPrompts.jsx
@@ -69,6 +69,15 @@ const ContextualQueryPrompts = ({
               color="primary"
               sx={{ 
                 fontSize: '0.7rem',
+                minHeight: 44,
+                '& .MuiChip-label': {
+                  px: 1.5,
+                },
+                '&:focus-visible': {
+                  outline: '2px solid',
+                  outlineColor: 'primary.main',
+                  outlineOffset: 2,
+                },
                 '&:hover': { 
                   backgroundColor: 'primary.light',
                   color: 'white'
@@ -92,7 +101,19 @@ const ContextualQueryPrompts = ({
             {title}
           </Typography>
           {hasMore && (
-            <IconButton size="small" onClick={() => setExpanded(!expanded)}>
+            <IconButton
+              size="medium"
+              onClick={() => setExpanded(!expanded)}
+              sx={{
+                minWidth: 44,
+                minHeight: 44,
+                '&:focus-visible': {
+                  outline: '2px solid',
+                  outlineColor: 'primary.main',
+                  outlineOffset: 2,
+                },
+              }}
+            >
               {expanded ? <ExpandLessIcon /> : <ExpandMoreIcon />}
             </IconButton>
           )}
@@ -115,6 +136,7 @@ const ContextualQueryPrompts = ({
                 alignItems: 'center',
                 gap: 1,
                 p: 1.5,
+                minHeight: 44,
                 borderRadius: 1,
                 backgroundColor: 'white',
                 textDecoration: 'none',
@@ -126,7 +148,12 @@ const ContextualQueryPrompts = ({
                   borderColor: 'primary.main',
                   backgroundColor: 'primary.50',
                   transform: 'translateX(4px)',
-                }
+                },
+                '&:focus-visible': {
+                  outline: '2px solid',
+                  outlineColor: 'primary.main',
+                  outlineOffset: 2,
+                },
               }}
             >
               <SearchIcon color="primary" sx={{ fontSize: 20 }} />
@@ -155,7 +182,15 @@ const ContextualQueryPrompts = ({
               fullWidth
               variant="text"
               onClick={() => setExpanded(true)}
-              sx={{ mt: 1 }}
+              sx={{
+                mt: 1,
+                minHeight: 44,
+                '&:focus-visible': {
+                  outline: '2px solid',
+                  outlineColor: 'primary.main',
+                  outlineOffset: 2,
+                },
+              }}
             >
               Show {sortedQueries.length - initialCount} more queries
             </Button>

--- a/src/components/InningsScatter.jsx
+++ b/src/components/InningsScatter.jsx
@@ -180,7 +180,7 @@ const InningsScatter = ({ innings, wrapInCard = true, shareView = false }) => {
               dataKey={xAxisMetrics[xMetric].key}
               name={xAxisMetrics[xMetric].label}
               label={isMobile ? undefined : { value: xAxisMetrics[xMetric].label, position: 'bottom', offset: 0 }}
-              tick={{ fontSize: isCompact ? 8 : 12 }}
+              tick={{ fontSize: isCompact ? 8 : 12, fill: designColors.neutral[800] }}
             />
             <YAxis
               type="number"
@@ -192,7 +192,7 @@ const InningsScatter = ({ innings, wrapInCard = true, shareView = false }) => {
                 position: 'insideLeft',
                 offset: 10
               }}
-              tick={{ fontSize: isCompact ? 8 : 12 }}
+              tick={{ fontSize: isCompact ? 8 : 12, fill: designColors.neutral[800] }}
             />
             {yMetric === 'strike_rate' && <ReferenceLine y={100} stroke={designColors.neutral[500]} strokeDasharray="3 3" />}
             {yMetric === 'sr_diff' && <ReferenceLine y={0} stroke={designColors.neutral[500]} strokeDasharray="3 3" />}

--- a/src/components/PaceSpinBreakdown.jsx
+++ b/src/components/PaceSpinBreakdown.jsx
@@ -127,11 +127,21 @@ const PaceSpinBreakdown = ({ stats, isMobile: isMobileProp, wrapInCard = true })
               type="number"
               domain={[0, maxValue * 1.1]}
               tickFormatter={(value) => Number(value.toFixed(2))}
-              tick={{ fontSize: isMobile ? 10 : 12 }}
+              tick={{ fontSize: isMobile ? 10 : 12, fill: designColors.neutral[800] }}
             />
-            <YAxis type="category" dataKey="phase" axisLine={false} tick={{ fontSize: isMobile ? 10 : 12 }} />
+            <YAxis
+              type="category"
+              dataKey="phase"
+              axisLine={false}
+              tick={{ fontSize: isMobile ? 10 : 12, fill: designColors.neutral[800] }}
+            />
             <Tooltip content={<CustomTooltip />} />
-            <Legend wrapperStyle={{ fontSize: isMobile ? '0.75rem' : '0.875rem' }} />
+            <Legend
+              wrapperStyle={{
+                fontSize: isMobile ? '0.75rem' : '0.875rem',
+                color: designColors.neutral[800],
+              }}
+            />
             <Bar dataKey="pace" name="vs Pace" fill={designColors.chart.blue} barSize={20} />
             <Bar dataKey="spin" name="vs Spin" fill={designColors.chart.orange} barSize={20} />
             <Bar dataKey="overall" name="Overall" fill={designColors.chart.green} barSize={20} />

--- a/src/components/PhasePerformanceRadar.jsx
+++ b/src/components/PhasePerformanceRadar.jsx
@@ -113,10 +113,10 @@ const PhasePerformanceRadar = ({ stats, isMobile: isMobileProp, wrapInCard = tru
             <PolarGrid />
             <PolarAngleAxis
               dataKey="phase"
-              tick={{ fontSize: isMobile ? 10 : 12 }}
+              tick={{ fontSize: isMobile ? 10 : 12, fill: designColors.neutral[800] }}
             />
             <PolarRadiusAxis
-              tick={{ fontSize: isMobile ? 9 : 11 }}
+              tick={{ fontSize: isMobile ? 9 : 11, fill: designColors.neutral[800] }}
             />
             {metrics.map((metric) => (
               <Radar
@@ -132,7 +132,7 @@ const PhasePerformanceRadar = ({ stats, isMobile: isMobileProp, wrapInCard = tru
               contentStyle={{ fontSize: isMobile ? '0.75rem' : '0.875rem' }}
             />
             <Legend
-              wrapperStyle={{ fontSize: isMobile ? '0.7rem' : '0.875rem' }}
+              wrapperStyle={{ fontSize: isMobile ? '0.7rem' : '0.875rem', color: designColors.neutral[800] }}
               iconSize={isMobile ? 8 : 14}
             />
           </RadarChart>

--- a/src/components/PlayerProfile.jsx
+++ b/src/components/PlayerProfile.jsx
@@ -323,6 +323,7 @@ const PlayerProfile = () => {
       startIcon={<FilterListIcon />}
       onClick={() => setFilterDrawerOpen(true)}
       sx={{
+        minHeight: 44,
         borderRadius: `${borderRadius.base}px`,
         borderColor: colors.neutral[300],
         color: colors.neutral[700],
@@ -332,6 +333,10 @@ const PlayerProfile = () => {
         '&:hover': {
           borderColor: colors.primary[400],
           backgroundColor: colors.primary[50],
+        },
+        '&:focus-visible': {
+          outline: `2px solid ${colors.primary[600]}`,
+          outlineOffset: 2,
         },
       }}
     >
@@ -471,7 +476,7 @@ const PlayerProfile = () => {
                   isMobile={isMobile}
                   columns={{ xs: '1fr', md: 'repeat(2, minmax(0, 1fr))' }}
                 >
-                  <VisualizationCard isMobile={isMobile}>
+                  <VisualizationCard isMobile={isMobile} ariaLabel="Wagon wheel shot map">
                     <WagonWheel
                       playerName={selectedPlayer}
                       startDate={dateRange.start}
@@ -484,7 +489,7 @@ const PlayerProfile = () => {
                       wrapInCard={false}
                     />
                   </VisualizationCard>
-                  <VisualizationCard isMobile={isMobile}>
+                  <VisualizationCard isMobile={isMobile} ariaLabel="Pitch map distribution">
                     <PlayerPitchMap
                       playerName={selectedPlayer}
                       startDate={dateRange.start}
@@ -504,16 +509,16 @@ const PlayerProfile = () => {
                   isMobile={isMobile}
                   columns={{ xs: '1fr', md: 'repeat(2, minmax(0, 1fr))' }}
                 >
-                  <VisualizationCard isMobile={isMobile}>
+                  <VisualizationCard isMobile={isMobile} ariaLabel="Phase performance radar chart">
                     <PhasePerformanceRadar stats={stats} isMobile={isMobile} wrapInCard={false} />
                   </VisualizationCard>
-                  <VisualizationCard isMobile={isMobile}>
+                  <VisualizationCard isMobile={isMobile} ariaLabel="Pace versus spin breakdown chart">
                     <PaceSpinBreakdown stats={stats} isMobile={isMobile} wrapInCard={false} />
                   </VisualizationCard>
-                  <VisualizationCard isMobile={isMobile}>
+                  <VisualizationCard isMobile={isMobile} ariaLabel="Innings scatter plot">
                     <InningsScatter innings={stats.innings} isMobile={isMobile} wrapInCard={false} />
                   </VisualizationCard>
-                  <VisualizationCard isMobile={isMobile}>
+                  <VisualizationCard isMobile={isMobile} ariaLabel="Strike rate progression chart">
                     <StrikeRateProgression
                       selectedPlayer={selectedPlayer}
                       dateRange={dateRange}
@@ -523,10 +528,10 @@ const PlayerProfile = () => {
                       wrapInCard={false}
                     />
                   </VisualizationCard>
-                  <VisualizationCard isMobile={isMobile}>
+                  <VisualizationCard isMobile={isMobile} ariaLabel="Ball-by-ball run distribution">
                     <BallRunDistribution innings={stats.innings} isMobile={isMobile} wrapInCard={false} />
                   </VisualizationCard>
-                  <VisualizationCard isMobile={isMobile}>
+                  <VisualizationCard isMobile={isMobile} ariaLabel="Strike rate intervals chart">
                     <StrikeRateIntervals ballStats={stats.ball_by_ball_stats} isMobile={isMobile} wrapInCard={false} />
                   </VisualizationCard>
                 </Section>
@@ -536,10 +541,10 @@ const PlayerProfile = () => {
                   isMobile={isMobile}
                   columns={{ xs: '1fr', lg: 'repeat(2, minmax(0, 1fr))' }}
                 >
-                  <VisualizationCard isMobile={isMobile}>
+                  <VisualizationCard isMobile={isMobile} ariaLabel="Top innings table">
                     <TopInnings innings={stats.innings} count={10} isMobile={isMobile} wrapInCard={false} />
                   </VisualizationCard>
-                  <VisualizationCard isMobile={isMobile}>
+                  <VisualizationCard isMobile={isMobile} ariaLabel="Bowling type matchup matrix">
                     <BowlingMatchupMatrix stats={stats} isMobile={isMobile} wrapInCard={false} />
                   </VisualizationCard>
                 </Section>

--- a/src/components/StrikeRateIntervals.jsx
+++ b/src/components/StrikeRateIntervals.jsx
@@ -139,7 +139,7 @@ const StrikeRateIntervals = ({ ballStats = [], isMobile: isMobileProp, wrapInCar
                 position: 'bottom',
                 offset: -5
               }}
-              tick={{ fontSize: isMobile ? 10 : 12 }}
+              tick={{ fontSize: isMobile ? 10 : 12, fill: designColors.neutral[800] }}
             />
             <YAxis
               yAxisId="left"
@@ -151,7 +151,7 @@ const StrikeRateIntervals = ({ ballStats = [], isMobile: isMobileProp, wrapInCar
                 position: 'insideLeft',
                 offset: 10
               }}
-              tick={{ fontSize: isMobile ? 10 : 12 }}
+              tick={{ fontSize: isMobile ? 10 : 12, fill: designColors.neutral[800] }}
             />
             <YAxis
               yAxisId="right"
@@ -163,10 +163,15 @@ const StrikeRateIntervals = ({ ballStats = [], isMobile: isMobileProp, wrapInCar
                 position: 'insideRight',
                 offset: 10
               }}
-              tick={{ fontSize: isMobile ? 10 : 12 }}
+              tick={{ fontSize: isMobile ? 10 : 12, fill: designColors.neutral[800] }}
             />
             <Tooltip content={<CustomTooltip />} />
-            <Legend wrapperStyle={{ fontSize: isMobile ? '0.75rem' : '0.875rem' }} />
+            <Legend
+              wrapperStyle={{
+                fontSize: isMobile ? '0.75rem' : '0.875rem',
+                color: designColors.neutral[800],
+              }}
+            />
             <Bar
               yAxisId="left"
               dataKey="strikeRate"

--- a/src/components/StrikeRateProgression.jsx
+++ b/src/components/StrikeRateProgression.jsx
@@ -84,19 +84,19 @@ const StrikeRateProgression = ({ selectedPlayer, dateRange, selectedVenue, compe
             <XAxis
               dataKey="ball_number"
               label={isMobile ? undefined : { value: 'Ball Number', position: 'bottom', offset: 10 }}
-              tick={{ fontSize: isMobile ? 10 : 12 }}
+              tick={{ fontSize: isMobile ? 10 : 12, fill: designColors.neutral[800] }}
             />
             <YAxis
               yAxisId="left"
               domain={[minSR, maxSR]}
               label={isMobile ? undefined : { value: 'Strike Rate', angle: -90, position: 'insideLeft' }}
-              tick={{ fontSize: isMobile ? 10 : 12 }}
+              tick={{ fontSize: isMobile ? 10 : 12, fill: designColors.neutral[800] }}
             />
             <YAxis
               yAxisId="right"
               orientation="right"
               label={isMobile ? undefined : { value: 'Number of Innings', angle: 90, position: 'insideRight' }}
-              tick={{ fontSize: isMobile ? 10 : 12 }}
+              tick={{ fontSize: isMobile ? 10 : 12, fill: designColors.neutral[800] }}
             />
             <Tooltip
               formatter={(value, name) => {
@@ -120,7 +120,8 @@ const StrikeRateProgression = ({ selectedPlayer, dateRange, selectedVenue, compe
                 display: 'flex',
                 justifyContent: 'center',
                 gap: isMobile ? '20px' : '50px',
-                fontSize: isMobile ? '0.75rem' : '0.875rem'
+                fontSize: isMobile ? '0.75rem' : '0.875rem',
+                color: designColors.neutral[800],
               }}
             />
             <Line

--- a/src/components/playerProfile/FilterBar.jsx
+++ b/src/components/playerProfile/FilterBar.jsx
@@ -16,6 +16,7 @@ const FilterBar = ({
 
   const inputStyles = {
     '& .MuiInputBase-root': {
+      minHeight: 44,
       borderRadius: `${borderRadius.base}px`,
       backgroundColor: colors.neutral[0],
     },
@@ -27,6 +28,7 @@ const FilterBar = ({
     },
     '&.Mui-focused .MuiOutlinedInput-notchedOutline': {
       borderColor: colors.primary[600],
+      borderWidth: 2,
     },
   };
 
@@ -116,9 +118,14 @@ const FilterBar = ({
         fullWidth
         size="medium"
         sx={{
+          minHeight: 44,
           borderRadius: `${borderRadius.base}px`,
           textTransform: 'none',
           fontWeight: typography.fontWeight.semibold,
+          '&:focus-visible': {
+            outline: `2px solid ${colors.primary[600]}`,
+            outlineOffset: 2,
+          },
         }}
       >
         GO

--- a/src/components/playerProfile/FilterSheet.jsx
+++ b/src/components/playerProfile/FilterSheet.jsx
@@ -18,6 +18,7 @@ const touchTargetStyles = {
   },
   '&.Mui-focused .MuiOutlinedInput-notchedOutline': {
     borderColor: colors.primary[600],
+    borderWidth: 2,
   },
 };
 
@@ -113,9 +114,14 @@ const FilterSheet = ({
           onClick={handleApply}
           disabled={!draftValues.player || loading}
           sx={{
+            minHeight: 44,
             borderRadius: `${borderRadius.base}px`,
             textTransform: 'none',
             fontWeight: typography.fontWeight.semibold,
+            '&:focus-visible': {
+              outline: `2px solid ${colors.primary[600]}`,
+              outlineOffset: 2,
+            },
           }}
         >
           Apply Filters

--- a/src/components/ui/FilterBar.jsx
+++ b/src/components/ui/FilterBar.jsx
@@ -40,6 +40,7 @@ const FilterItem = ({ label, value, options, onChange, isMobile, fullWidth = fal
         label={label}
         onChange={onChange}
         sx={{
+          minHeight: 44,
           fontSize: isMobile ? typography.fontSize.sm : typography.fontSize.base,
           borderRadius: `${borderRadius.base}px`,
           backgroundColor: colors.neutral[0],
@@ -55,6 +56,12 @@ const FilterItem = ({ label, value, options, onChange, isMobile, fullWidth = fal
           },
           '&.Mui-focused .MuiOutlinedInput-notchedOutline': {
             borderColor: colors.primary[600],
+            borderWidth: 2,
+          },
+          '& .MuiSelect-select': {
+            display: 'flex',
+            alignItems: 'center',
+            minHeight: 44,
           },
         }}
       >
@@ -64,6 +71,7 @@ const FilterItem = ({ label, value, options, onChange, isMobile, fullWidth = fal
             value={option.value}
             sx={{
               fontSize: isMobile ? typography.fontSize.sm : typography.fontSize.base,
+              minHeight: 44,
             }}
           >
             {option.label}
@@ -124,6 +132,7 @@ const FilterBar = ({
             startIcon={<FilterListIcon />}
             onClick={() => setMobileDrawerOpen(true)}
             sx={{
+              minHeight: 44,
               borderRadius: `${borderRadius.base}px`,
               borderColor: colors.neutral[300],
               color: colors.neutral[700],
@@ -133,6 +142,10 @@ const FilterBar = ({
               '&:hover': {
                 borderColor: colors.primary[400],
                 backgroundColor: colors.primary[50],
+              },
+              '&:focus-visible': {
+                outline: `2px solid ${colors.primary[600]}`,
+                outlineOffset: 2,
               },
             }}
           >
@@ -180,7 +193,18 @@ const FilterBar = ({
               <Typography variant="h6" sx={{ fontWeight: typography.fontWeight.semibold }}>
                 Filters
               </Typography>
-              <IconButton onClick={() => setMobileDrawerOpen(false)} size="small">
+              <IconButton
+                onClick={() => setMobileDrawerOpen(false)}
+                size="medium"
+                sx={{
+                  minWidth: 44,
+                  minHeight: 44,
+                  '&:focus-visible': {
+                    outline: `2px solid ${colors.primary[600]}`,
+                    outlineOffset: 2,
+                  },
+                }}
+              >
                 <CloseIcon />
               </IconButton>
             </Box>
@@ -197,9 +221,14 @@ const FilterBar = ({
               onClick={() => setMobileDrawerOpen(false)}
               sx={{
                 mt: `${spacing.lg}px`,
+                minHeight: 44,
                 borderRadius: `${borderRadius.base}px`,
                 textTransform: 'none',
                 fontWeight: typography.fontWeight.semibold,
+                '&:focus-visible': {
+                  outline: `2px solid ${colors.primary[600]}`,
+                  outlineOffset: 2,
+                },
               }}
             >
               Apply Filters

--- a/src/components/ui/FilterDrawer.jsx
+++ b/src/components/ui/FilterDrawer.jsx
@@ -47,7 +47,19 @@ const FilterDrawer = ({ open, onClose, title = 'Filters', children, footer }) =>
           <Typography variant="h6" sx={{ fontWeight: typography.fontWeight.semibold }}>
             {title}
           </Typography>
-          <IconButton onClick={onClose} size="small" sx={{ color: colors.neutral[600] }}>
+          <IconButton
+            onClick={onClose}
+            size="medium"
+            sx={{
+              color: colors.neutral[600],
+              minWidth: 44,
+              minHeight: 44,
+              '&:focus-visible': {
+                outline: `2px solid ${colors.primary[600]}`,
+                outlineOffset: 2,
+              },
+            }}
+          >
             <CloseIcon />
           </IconButton>
         </Box>

--- a/src/components/ui/VisualizationCard.jsx
+++ b/src/components/ui/VisualizationCard.jsx
@@ -1,7 +1,7 @@
 /**
  * VisualizationCard Component - consistent visualization container with slots
  */
-import React from 'react';
+import React, { useId } from 'react';
 import { Box, Typography } from '@mui/material';
 import Card from './Card';
 import { colors, spacing, typography } from '../../theme/designSystem';
@@ -10,6 +10,7 @@ const VisualizationCard = ({
   title,
   subtitle,
   actions,
+  ariaLabel,
   children,
   isMobile = false,
   sx = {},
@@ -17,6 +18,13 @@ const VisualizationCard = ({
   contentSx = {},
   ...props
 }) => {
+  const titleId = useId();
+  const ariaProps = title
+    ? { 'aria-labelledby': titleId }
+    : ariaLabel
+        ? { 'aria-label': ariaLabel }
+        : {};
+
   return (
     <Card
       isMobile={isMobile}
@@ -26,6 +34,8 @@ const VisualizationCard = ({
         gap: `${spacing.base}px`,
         ...sx,
       }}
+      role="region"
+      {...ariaProps}
       {...props}
     >
       {(title || subtitle || actions) && (
@@ -47,6 +57,7 @@ const VisualizationCard = ({
                   fontWeight: typography.fontWeight.semibold,
                   color: colors.neutral[900],
                 }}
+                id={titleId}
               >
                 {title}
               </Typography>


### PR DESCRIPTION
### Motivation
- Ensure all interactive controls in the Player Profile meet mobile touch target guidelines (≥44px) for easier tapping.
- Make keyboard focus visible and match the theme by using a 2px primary focus ring for form controls and buttons.
- Improve screen reader support for visualization areas by adding ARIA labels or descriptive headers.
- Increase chart text contrast against neutral backgrounds so axis/legend text meets accessibility expectations.

### Description
- Enforced larger touch targets and consistent focus styles by adding `minHeight: 44` and `&:focus-visible` outlines across filter and control components including `src/components/playerProfile/FilterBar.jsx`, `FilterSheet.jsx`, `src/components/ui/FilterBar.jsx`, `CompetitionFilter.jsx`, `ContextualQueryPrompts.jsx` and `ui/FilterDrawer.jsx`.
- Added an `ariaLabel` prop and proper `role` / `aria-labelledby` handling in `src/components/ui/VisualizationCard.jsx` and applied `ariaLabel` values in `src/components/PlayerProfile.jsx` for visualization cards that previously lacked visible headers.
- Increased chart axis/legend text contrast by switching tick/legend colors to `designColors.neutral[800]` in chart components such as `PhasePerformanceRadar.jsx`, `PaceSpinBreakdown.jsx`, `InningsScatter.jsx`, `BallRunDistribution.jsx`, `StrikeRateIntervals.jsx`, and `StrikeRateProgression.jsx`.
- Adjusted select/menu item sizing and icon button dimensions (min width/height) so dropdowns, chips, and icon controls also meet touch target and focus requirements.

### Testing
- Started the development server with `npm start` and confirmed the app compiled and the dev server started (build emitted lint warnings but completed).
- Captured a headless rendering of the Player Profile page with Playwright by visiting `/player` and saving a screenshot, which completed successfully and produced `artifacts/player-profile.png`.
- Committed the changes and verified a clean Git commit containing the accessibility updates.
- No unit or integration test suites were executed as part of these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695a034b0bc0832c8dc7ee44846d692b)