### PR TITLE
Make wagon wheel & pitch map responsive and transpose bowling matchup table

### DIFF
--- a/src/components/BowlingMatchupMatrix.jsx
+++ b/src/components/BowlingMatchupMatrix.jsx
@@ -3,6 +3,7 @@ import { Typography, Box, Tooltip, useMediaQuery, useTheme } from '@mui/material
 import { Info as InfoIcon } from 'lucide-react';
 import Card from './ui/Card';
 import { EmptyState } from './ui';
+import { colors } from '../theme/designSystem';
 
 const MetricCell = ({ stats, isMobile }) => {
   if (!stats || !stats.runs) return <td style={{ textAlign: 'center', padding: '8px' }}>-</td>;
@@ -86,25 +87,48 @@ const BowlingMatchupMatrix = ({ stats, isMobile: isMobileProp, wrapInCard = true
           <InfoIcon size={isMobile ? 14 : 16} />
         </Tooltip>
       </Box>
-      <Box sx={{ overflow: 'auto' }}>
+      <Box sx={{ overflowY: 'auto', maxHeight: isMobile ? 360 : 420 }}>
         <table style={{ width: '100%', borderCollapse: 'collapse', fontSize: isMobile ? '0.75rem' : undefined }}>
           <thead>
             <tr>
-              <th style={{ textAlign: 'left', padding: isMobile ? '6px' : '8px' }}>Phase</th>
-              {bowlingTypes.map(type => (
-                <th key={type} style={{ textAlign: 'center', padding: isMobile ? '6px' : '8px', minWidth: isMobile ? '100px' : '120px' }}>
-                  {type}
+              <th
+                style={{
+                  textAlign: 'left',
+                  padding: isMobile ? '6px' : '8px',
+                  position: 'sticky',
+                  top: 0,
+                  background: colors.neutral[0],
+                  zIndex: 2
+                }}
+              >
+                Bowling Type
+              </th>
+              {phases.map(phase => (
+                <th
+                  key={phase}
+                  style={{
+                    textAlign: 'center',
+                    padding: isMobile ? '6px' : '8px',
+                    minWidth: isMobile ? '100px' : '120px',
+                    position: 'sticky',
+                    top: 0,
+                    background: colors.neutral[0],
+                    zIndex: 2,
+                    textTransform: 'capitalize'
+                  }}
+                >
+                  {phase}
                 </th>
               ))}
             </tr>
           </thead>
           <tbody>
-            {phases.map(phase => (
-              <tr key={phase}>
-                <td style={{ padding: isMobile ? '6px' : '8px', textTransform: 'capitalize' }}>{phase}</td>
-                {bowlingTypes.map(type => (
+            {bowlingTypes.map(type => (
+              <tr key={type}>
+                <td style={{ padding: isMobile ? '6px' : '8px', textTransform: 'capitalize' }}>{type}</td>
+                {phases.map(phase => (
                   <MetricCell
-                    key={type}
+                    key={phase}
                     stats={stats?.phase_stats?.bowling_types?.[type]?.[phase]}
                     isMobile={isMobile}
                   />

--- a/src/components/PitchMap/PitchMapVisualization.jsx
+++ b/src/components/PitchMap/PitchMapVisualization.jsx
@@ -160,7 +160,7 @@ const PitchMapVisualization = ({
         ref={svgRef}
         width={scaledDimensions.width} 
         height={scaledDimensions.height}
-        style={{ overflow: 'visible', maxWidth: '100%' }}
+        style={{ overflow: 'hidden', maxWidth: '100%', display: 'block' }}
       >
         {/* Background pitch */}
         <rect

--- a/src/components/PlayerPitchMap.jsx
+++ b/src/components/PlayerPitchMap.jsx
@@ -37,7 +37,7 @@ const PlayerPitchMap = ({
   const isCompact = shareView || isMobile;
   const Wrapper = wrapInCard ? Card : Box;
   const frameSx = isMobile
-    ? { minHeight: 420, aspectRatio: '4 / 5' }
+    ? { minHeight: 420 }
     : {};
   const wrapperProps = wrapInCard
     ? { isMobile, shareFrame: shareView, sx: frameSx }
@@ -253,7 +253,14 @@ const PlayerPitchMap = ({
       </Box>
 
       {/* Pitch Map Visualization */}
-      <Box sx={{ maxWidth: isCompact ? 360 : 420, mx: 'auto', width: '100%' }}>
+      <Box
+        sx={{
+          maxWidth: isCompact ? 360 : 420,
+          mx: 'auto',
+          width: '100%',
+          overflow: 'hidden'
+        }}
+      >
         <PitchMapVisualization
           cells={pitchData.cells}
           mode="grid"

--- a/src/components/TopInnings.jsx
+++ b/src/components/TopInnings.jsx
@@ -106,8 +106,10 @@ const TopInnings = ({ innings, count = 10, isMobile = false, wrapInCard = true }
           minHeight={isMobile ? 240 : 280}
         />
       ) : (
-      <TableContainer>
+      <TableContainer sx={{ width: '100%', overflowX: 'auto' }}>
         <Table size={isMobile ? "small" : "medium"} sx={{
+          tableLayout: 'fixed',
+          width: '100%',
           '& .MuiTableCell-root': {
             borderBottom: '1px solid rgba(224, 224, 224, 1)',
             py: isMobile ? `${spacing.xs}px` : `${spacing.md}px`,


### PR DESCRIPTION
### Motivation
- Prevent the wagon wheel and pitch map SVGs from overflowing their cards by constraining their container sizes and making them responsive.
- Present Bowling Type Matchups with phases as columns and bowling types as rows so the table is easier to scan vertically on smaller screens.
- Keep the Top Innings table constrained to card width and enable safe horizontal/vertical scrolling so it does not force the layout to expand.

### Description
- Replace WagonWheel window resize hack with a `ResizeObserver` on a chart container, added `chartContainerRef` and `containerSize` state, and cap SVG width via `maxWidth` to keep the field inside the card.
- Constrain `PlayerPitchMap` visualization wrapper to `maxWidth` and add `overflow: hidden` so the `PitchMapVisualization` does not overflow the card.
- Change `PitchMapVisualization` SVG styling to `overflow: hidden` and `display: block` to avoid overflow artifacts.
- Transpose `BowlingMatchupMatrix` so bowling types are rows and phases are columns, add sticky headers and a vertical scroll container with a `maxHeight`, and use the theme neutral background for the sticky header.
- Make `TopInnings` table use `tableLayout: 'fixed'`, `width: '100%'` and wrap it in a `TableContainer` with `overflowX: 'auto'` to keep the table inside the card and allow horizontal scrolling when needed.

### Testing
- Ran `npm start` and fixed an initial lint/compile error caused by a stray variable, after which the dev server started successfully. 
- Attempted an automated visual check via Playwright to capture a mobile screenshot, but the Chromium instance crashed (SIGSEGV/TargetClosedError) and the screenshot run failed. 
- No unit tests were added or run as these are UI/layout changes. 
- Changes were committed after resolving the compile error.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6959ed8034d4832c850571c3d70421d9)