### PR TITLE
Add automation docs and weekly GitHub Actions workflow

### DIFF
--- a/.github/workflows/refresh-delivery-details.yml
+++ b/.github/workflows/refresh-delivery-details.yml
@@ -1,0 +1,29 @@
+name: Refresh delivery details
+
+on:
+  schedule:
+    - cron: "0 3 * * 0"
+  workflow_dispatch:
+
+jobs:
+  refresh:
+    runs-on: ubuntu-latest
+    env:
+      DATABASE_URL: ${{ secrets.DATABASE_URL }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+
+      - name: Run delivery details sync
+        run: |
+          python run_full_dd_sync.py --confirm

--- a/docs/automation.md
+++ b/docs/automation.md
@@ -1,0 +1,57 @@
+# Automation for Delivery Details Sync
+
+This project’s delivery details refresh is driven by the entrypoint script `run_full_dd_sync.py`. It expects a `DATABASE_URL` environment variable that points at the target PostgreSQL database.
+
+## Cron (weekly)
+
+Example cron entry to run every Sunday at 03:00. Adjust paths to your checkout and Python environment:
+
+```cron
+0 3 * * 0 cd /path/to/cricket-data-thing \
+  && source /path/to/venv/bin/activate \
+  && DATABASE_URL="postgresql://user:pass@host:5432/dbname" \
+  python run_full_dd_sync.py --confirm
+```
+
+## systemd timer (optional)
+
+For long-running jobs, a systemd timer avoids cron timeouts and provides journal logs. Example:
+
+**`/etc/systemd/system/cricket-dd-sync.service`**
+```ini
+[Unit]
+Description=Weekly delivery_details sync
+
+[Service]
+Type=oneshot
+WorkingDirectory=/path/to/cricket-data-thing
+Environment=DATABASE_URL=postgresql://user:pass@host:5432/dbname
+ExecStart=/path/to/venv/bin/python run_full_dd_sync.py --confirm
+```
+
+**`/etc/systemd/system/cricket-dd-sync.timer`**
+```ini
+[Unit]
+Description=Weekly delivery_details sync timer
+
+[Timer]
+OnCalendar=Sun *-*-* 03:00:00
+Persistent=true
+
+[Install]
+WantedBy=timers.target
+```
+
+Enable the timer:
+
+```bash
+sudo systemctl daemon-reload
+sudo systemctl enable --now cricket-dd-sync.timer
+```
+
+## GitHub Actions (CI preferred)
+
+If you want a hosted weekly run, use the workflow in `.github/workflows/refresh-delivery-details.yml`. It runs `run_full_dd_sync.py` and pulls the database connection string from `DATABASE_URL` in repository secrets.
+
+Expected environment variables:
+- `DATABASE_URL`: PostgreSQL connection string used by `run_full_dd_sync.py`.


### PR DESCRIPTION
### Motivation
- Provide operators a clear, supported way to run the delivery details refresh on a schedule using the new entrypoint script `run_full_dd_sync.py`.
- Offer multiple automation options (cron, systemd timer, and CI) so teams can pick the most appropriate runner for long-running DB jobs.
- Make the required environment variable (`DATABASE_URL`) explicit so CI and system services can be configured correctly.

### Description
- Add `docs/automation.md` documenting a weekly `cron` example, an optional `systemd` timer/service, and CI guidance that references `run_full_dd_sync.py` and `DATABASE_URL`.
- Add `.github/workflows/refresh-delivery-details.yml` which runs weekly (cron `0 3 * * 0`) and on-demand via `workflow_dispatch`, installs dependencies, and runs `python run_full_dd_sync.py --confirm` using `DATABASE_URL` from repository secrets.
- The docs include example `cron` entry, example `systemd` unit and timer files, and the exact expected environment variable name `DATABASE_URL`.

### Testing
- No automated tests were run because this change only adds documentation and a workflow file.
- The new GitHub Actions workflow file has been added but not executed in CI as part of this change.
- Manual validation consisted of file creation and basic syntax checks of the YAML and markdown files in the repository.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6963889a5f34832cbbc2334ec4e70268)