### PR TITLE
Replace inline DB connection strings with `DATABASE_URL` in docs and scripts

### DIFF
--- a/README-SETUP.md
+++ b/README-SETUP.md
@@ -81,7 +81,7 @@
 - Push to Heroku using git or CLI
 
 ### Environment Variables
-- `DATABASE_URL`: PostgreSQL connection string (automatically set by Heroku)
+- `DATABASE_URL`: PostgreSQL connection string (automatically set by Heroku). For local development, keep it in a `.env` file loaded by your shell; for scheduled jobs, store it in a secret manager and inject it as an environment variable.
 
 ## Project Structure
 - `cricket-data-thing/`: FastAPI backend

--- a/README.md
+++ b/README.md
@@ -191,8 +191,7 @@ pip install -r requirements.txt
 
 # Set up environment variables
 cp .env.example .env
-# Edit .env with your database credentials
-#for quickly getting things done locally, change the DATABASE_URL in database.py file
+# Edit .env with your database credentials (set DATABASE_URL here)
 
 # Start the API server
 uvicorn main:app --reload

--- a/docs/automation.md
+++ b/docs/automation.md
@@ -1,6 +1,6 @@
 # Automation for Delivery Details Sync
 
-This project’s delivery details refresh is driven by the entrypoint script `run_full_dd_sync.py`. It expects a `DATABASE_URL` environment variable that points at the target PostgreSQL database.
+This project’s delivery details refresh is driven by the entrypoint script `run_full_dd_sync.py`. It expects a `DATABASE_URL` environment variable that points at the target PostgreSQL database. Store the value in a local `.env` (for on-host jobs) or a secret manager (for scheduled workflows) instead of hard-coding it in command lines.
 
 ## Cron (weekly)
 
@@ -9,8 +9,8 @@ Example cron entry to run every Sunday at 03:00. Adjust paths to your checkout a
 ```cron
 0 3 * * 0 cd /path/to/cricket-data-thing \
   && source /path/to/venv/bin/activate \
-  && DATABASE_URL="postgresql://user:pass@host:5432/dbname" \
-  python run_full_dd_sync.py --confirm
+  && set -a && source /path/to/.env && set +a \
+  && python run_full_dd_sync.py --confirm
 ```
 
 ## systemd timer (optional)
@@ -25,7 +25,7 @@ Description=Weekly delivery_details sync
 [Service]
 Type=oneshot
 WorkingDirectory=/path/to/cricket-data-thing
-Environment=DATABASE_URL=postgresql://user:pass@host:5432/dbname
+EnvironmentFile=/path/to/.env
 ExecStart=/path/to/venv/bin/python run_full_dd_sync.py --confirm
 ```
 

--- a/scripts/add_left_right_columns.py
+++ b/scripts/add_left_right_columns.py
@@ -3,11 +3,11 @@ Add left-right analysis columns to delivery_details.
 Data is already loaded - just need to add and populate columns.
 
 Usage:
-    python scripts/add_left_right_columns.py --db-url "postgres://..."
+    python scripts/add_left_right_columns.py --db-url "$DATABASE_URL"
     python scripts/add_left_right_columns.py --dry-run
     
     # Using environment variable:
-    DATABASE_URL="postgresql://..." python scripts/add_left_right_columns.py
+    python scripts/add_left_right_columns.py
 """
 
 import os

--- a/scripts/cleanup_bad_aliases.py
+++ b/scripts/cleanup_bad_aliases.py
@@ -5,8 +5,9 @@ This script identifies and removes aliases created due to data mismatches betwee
 the deliveries and delivery_details tables.
 
 Usage:
-    python scripts/cleanup_bad_aliases.py --db-url "postgres://..." --dry-run
-    python scripts/cleanup_bad_aliases.py --db-url "postgres://..."
+    # Ensure DATABASE_URL is set (for example via a local .env)
+    python scripts/cleanup_bad_aliases.py --db-url "$DATABASE_URL" --dry-run
+    python scripts/cleanup_bad_aliases.py --db-url "$DATABASE_URL"
 """
 
 import os
@@ -162,10 +163,10 @@ def main():
         epilog="""
 Examples:
   # Dry run (show what would be deleted)
-  python scripts/cleanup_bad_aliases.py --db-url "postgres://..." --dry-run
+  python scripts/cleanup_bad_aliases.py --db-url "$DATABASE_URL" --dry-run
 
   # Actually delete invalid aliases
-  python scripts/cleanup_bad_aliases.py --db-url "postgres://..."
+  python scripts/cleanup_bad_aliases.py --db-url "$DATABASE_URL"
         """
     )
     parser.add_argument('--db-url', help='Database URL (or set DATABASE_URL env var)')

--- a/scripts/enhance_delivery_details.py
+++ b/scripts/enhance_delivery_details.py
@@ -3,7 +3,8 @@ Enhance delivery_details table with additional columns from CSV
 and left-right batter analysis columns.
 
 Usage:
-    DATABASE_URL="postgresql://..." python scripts/enhance_delivery_details.py
+    # Ensure DATABASE_URL is set (for example via a local .env)
+    python scripts/enhance_delivery_details.py
 """
 
 import os
@@ -22,7 +23,8 @@ DATABASE_URL = os.environ.get("DATABASE_URL")
 
 if not DATABASE_URL:
     print("ERROR: DATABASE_URL environment variable is required")
-    print('Usage: DATABASE_URL="postgresql://..." python scripts/enhance_delivery_details.py')
+    print("Usage: set DATABASE_URL in your environment (e.g., via .env) and run:")
+    print("  python scripts/enhance_delivery_details.py")
     sys.exit(1)
 
 # =============================================================================

--- a/scripts/load_delivery_details.py
+++ b/scripts/load_delivery_details.py
@@ -2,8 +2,8 @@
 Load enhanced ball-by-ball data into delivery_details table.
 
 Usage:
-    python scripts/load_delivery_details.py --csv /path/to/t20_bbb.csv --db-url "postgres://..."
-    python scripts/load_delivery_details.py --csv /path/to/t20_bbb.csv --db-url "postgres://..." --only-overlap
+    python scripts/load_delivery_details.py --csv /path/to/t20_bbb.csv --db-url "$DATABASE_URL"
+    python scripts/load_delivery_details.py --csv /path/to/t20_bbb.csv --db-url "$DATABASE_URL" --only-overlap
 """
 
 import os

--- a/scripts/load_delivery_details_full.py
+++ b/scripts/load_delivery_details_full.py
@@ -3,11 +3,11 @@ Load ALL columns from t20_bbb.csv into delivery_details table.
 Handles duplicates by only inserting new rows based on (p_match, inns, over, ball).
 
 Usage:
-    python scripts/load_delivery_details_full.py --csv /path/to/t20_bbb.csv --db-url "postgres://..."
+    python scripts/load_delivery_details_full.py --csv /path/to/t20_bbb.csv --db-url "$DATABASE_URL"
     python scripts/load_delivery_details_full.py --csv /path/to/t20_bbb.csv --dry-run
     
     # Using environment variable:
-    DATABASE_URL="postgres://..." python scripts/load_delivery_details_full.py --csv /path/to/t20_bbb.csv
+    python scripts/load_delivery_details_full.py --csv /path/to/t20_bbb.csv
 """
 
 import os

--- a/scripts/load_delivery_details_pipeline.py
+++ b/scripts/load_delivery_details_pipeline.py
@@ -10,16 +10,16 @@ This script orchestrates the full data loading pipeline:
 
 Usage:
     # Full pipeline with dry run
-    python scripts/load_delivery_details_pipeline.py --csv /path/to/t20_bbb.csv --db-url "postgres://..." --dry-run
+    python scripts/load_delivery_details_pipeline.py --csv /path/to/t20_bbb.csv --db-url "$DATABASE_URL" --dry-run
     
     # Full pipeline (actual execution)
-    python scripts/load_delivery_details_pipeline.py --csv /path/to/t20_bbb.csv --db-url "postgres://..."
+    python scripts/load_delivery_details_pipeline.py --csv /path/to/t20_bbb.csv --db-url "$DATABASE_URL"
     
     # Skip validation step
-    python scripts/load_delivery_details_pipeline.py --csv /path/to/t20_bbb.csv --db-url "postgres://..." --skip-validation
+    python scripts/load_delivery_details_pipeline.py --csv /path/to/t20_bbb.csv --db-url "$DATABASE_URL" --skip-validation
     
     # Using environment variable
-    DATABASE_URL="postgres://..." python scripts/load_delivery_details_pipeline.py --csv /path/to/t20_bbb.csv
+    python scripts/load_delivery_details_pipeline.py --csv /path/to/t20_bbb.csv
 """
 
 import os
@@ -213,13 +213,13 @@ Steps:
 
 Examples:
   # Dry run (no changes)
-  python scripts/load_delivery_details_pipeline.py --csv data.csv --db-url "postgres://..." --dry-run
+  python scripts/load_delivery_details_pipeline.py --csv data.csv --db-url "$DATABASE_URL" --dry-run
 
   # Full execution
-  python scripts/load_delivery_details_pipeline.py --csv data.csv --db-url "postgres://..."
+  python scripts/load_delivery_details_pipeline.py --csv data.csv --db-url "$DATABASE_URL"
 
   # Skip ELO calculation (faster)
-  python scripts/load_delivery_details_pipeline.py --csv data.csv --db-url "postgres://..." --skip-elo
+  python scripts/load_delivery_details_pipeline.py --csv data.csv --db-url "$DATABASE_URL" --skip-elo
         """
     )
     parser.add_argument('--csv', required=True, help='Path to t20_bbb.csv')

--- a/scripts/refresh_query_builder_metadata.py
+++ b/scripts/refresh_query_builder_metadata.py
@@ -2,11 +2,11 @@
 Refresh query_builder_metadata table with precomputed values.
 
 Run after data loads or periodically:
-    python scripts/refresh_query_builder_metadata.py --db-url "postgres://..."
+    python scripts/refresh_query_builder_metadata.py --db-url "$DATABASE_URL"
     python scripts/refresh_query_builder_metadata.py --show-only
     
     # Using environment variable:
-    DATABASE_URL="postgres://..." python scripts/refresh_query_builder_metadata.py
+    python scripts/refresh_query_builder_metadata.py
 """
 
 import os

--- a/scripts/run_delivery_details_refresh.sh
+++ b/scripts/run_delivery_details_refresh.sh
@@ -14,10 +14,11 @@ Requirements:
   - DATABASE_URL must be set in the environment.
 
 Examples:
-  DATABASE_URL="postgresql://..." scripts/run_delivery_details_refresh.sh \
+  # Ensure DATABASE_URL is set (for example: source /path/to/.env)
+  scripts/run_delivery_details_refresh.sh \
     --dropbox-url "https://www.dropbox.com/s/<id>/t20_bbb.csv?dl=0"
 
-  DATABASE_URL="postgresql://..." scripts/run_delivery_details_refresh.sh \
+  scripts/run_delivery_details_refresh.sh \
     --dropbox-url "https://www.dropbox.com/s/<id>/t20_bbb.csv" \
     --csv-path data/t20_bbb.csv --skip-elo --dry-run
 USAGE

--- a/scripts/update_players_from_new_data.py
+++ b/scripts/update_players_from_new_data.py
@@ -2,11 +2,11 @@
 Update players table with bat_hand/bowl_style from delivery_details.
 
 Usage:
-    python scripts/update_players_from_new_data.py --db-url "postgres://..." --dry-run
-    python scripts/update_players_from_new_data.py --db-url "postgres://..."
+    python scripts/update_players_from_new_data.py --db-url "$DATABASE_URL" --dry-run
+    python scripts/update_players_from_new_data.py --db-url "$DATABASE_URL"
     
     # Using environment variable:
-    DATABASE_URL="postgres://..." python scripts/update_players_from_new_data.py
+    python scripts/update_players_from_new_data.py
 """
 
 import os

--- a/scripts/update_players_from_new_data_FIXED.py
+++ b/scripts/update_players_from_new_data_FIXED.py
@@ -4,11 +4,11 @@ Update players table with bat_hand/bowl_style from delivery_details.
 FIXED VERSION: Adds last name validation to prevent incorrect alias mappings.
 
 Usage:
-    python scripts/update_players_from_new_data_FIXED.py --db-url "postgres://..." --dry-run
-    python scripts/update_players_from_new_data_FIXED.py --db-url "postgres://..."
+    python scripts/update_players_from_new_data_FIXED.py --db-url "$DATABASE_URL" --dry-run
+    python scripts/update_players_from_new_data_FIXED.py --db-url "$DATABASE_URL"
 
     # Using environment variable:
-    DATABASE_URL="postgres://..." python scripts/update_players_from_new_data_FIXED.py
+    python scripts/update_players_from_new_data_FIXED.py
 """
 
 import os

--- a/scripts/validate_new_dataset.py
+++ b/scripts/validate_new_dataset.py
@@ -9,11 +9,11 @@ database to identify:
 4. Coverage analysis
 
 Usage:
-    python scripts/validate_new_dataset.py --csv /path/to/t20_bbb.csv --db-url "postgres://..."
+    python scripts/validate_new_dataset.py --csv /path/to/t20_bbb.csv --db-url "$DATABASE_URL"
     python scripts/validate_new_dataset.py --csv /path/to/t20_bbb.csv --sample 100000
     
     # Using environment variable:
-    DATABASE_URL="postgres://..." python scripts/validate_new_dataset.py --csv /path/to/t20_bbb.csv
+    python scripts/validate_new_dataset.py --csv /path/to/t20_bbb.csv
 """
 
 import os


### PR DESCRIPTION
### Motivation
- Remove inline PostgreSQL connection strings from examples and encourage using the `DATABASE_URL` environment variable.
- Encourage secure storage of the DB URL in a local `.env` for on-host runs or a secret manager for scheduled jobs.
- Make script usage and automation examples consistent so scheduled jobs and CI pick up the connection string from environment.
- Reduce accidental exposure of credentials in docs and cron/systemd examples.

### Description
- Updated documentation to recommend storing `DATABASE_URL` in `.env` or a secret manager and adjusted examples in `README-SETUP.md`, `README.md`, and `docs/automation.md` to reflect this change.
- Rewrote automation examples to source a `.env` (`set -a && source /path/to/.env && set +a`) and switched systemd examples to use `EnvironmentFile=/path/to/.env`.
- Replaced inline connection-string examples in multiple scripts' usage blocks and epilog text to use `"$DATABASE_URL"` or to rely on the `DATABASE_URL` environment variable in `scripts/*.py` and `scripts/run_delivery_details_refresh.sh` (affected files include `load_delivery_details_pipeline.py`, `validate_new_dataset.py`, `load_delivery_details.py`, `load_delivery_details_full.py`, `add_left_right_columns.py`, `cleanup_bad_aliases.py`, `enhance_delivery_details.py`, `refresh_query_builder_metadata.py`, `update_players_from_new_data.py`, and `update_players_from_new_data_FIXED.py`).
- Improved a couple of script usage/help messages to instruct running after setting `DATABASE_URL` (e.g., `enhance_delivery_details.py` now prompts to set `DATABASE_URL` via `.env`).

### Testing
- No automated tests were run; these are documentation and usage-example changes only.
- Changes were committed and are limited to docstrings, README, automation docs, and script usage text so no runtime behavior was altered during this update.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6963895d3854832c93d89f4b209761d1)