### PR TITLE
Handle empty league filters in profile stats and improve player autocomplete

### DIFF
--- a/main.py
+++ b/main.py
@@ -1800,6 +1800,7 @@ def get_player_stats(
                         (m.team1 = ANY(:top_team_list) AND m.team2 = ANY(:top_team_list))
                     )
                 )
+                OR (NOT :has_leagues AND NOT :include_international)
             )
         """
 
@@ -2212,6 +2213,7 @@ def get_player_ball_stats(
                         (m.team1 = ANY(:top_team_list) AND m.team2 = ANY(:top_team_list))
                     )
                 )
+                OR (NOT :has_leagues AND NOT :include_international)
             )
         """
 
@@ -3198,6 +3200,7 @@ def get_player_bowling_stats(
                         (m.team1 = ANY(:top_team_list) AND m.team2 = ANY(:top_team_list))
                     )
                 )
+                OR (NOT :has_leagues AND NOT :include_international)
             )
         """
 

--- a/src/components/BowlerProfile.jsx
+++ b/src/components/BowlerProfile.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useMemo } from 'react';
+import React, { useState, useEffect, useMemo, useRef } from 'react';
 import { Container, Box, Button, Typography, Chip, useMediaQuery, useTheme } from '@mui/material';
 import FilterListIcon from '@mui/icons-material/FilterList';
 import { useLocation, useNavigate } from 'react-router-dom';
@@ -42,7 +42,9 @@ const BowlerProfile = () => {
   const [selectedPlayer, setSelectedPlayer] = useState(null);
   const [dateRange, setDateRange] = useState({ start: DEFAULT_START_DATE, end: TODAY });
   const [selectedVenue, setSelectedVenue] = useState("All Venues");
-  const [players, setPlayers] = useState([]);
+  const [playerOptions, setPlayerOptions] = useState([]);
+  const [playerSearchInput, setPlayerSearchInput] = useState('');
+  const [playerSearchLoading, setPlayerSearchLoading] = useState(false);
   const [venues, setVenues] = useState([]);
   const [competitionFilters, setCompetitionFilters] = useState({
     leagues: [],
@@ -57,49 +59,12 @@ const BowlerProfile = () => {
   const [dnaFetchTrigger, setDnaFetchTrigger] = useState(0);
   const [filterDrawerOpen, setFilterDrawerOpen] = useState(false);
 
-  // Add a direct event listener to trigger analysis on page load if needed
-  useEffect(() => {
-    // This function will run once when component mounts
-    const urlParams = new URLSearchParams(window.location.search);
-    const playerName = urlParams.get('name');
-    const autoload = urlParams.get('autoload') === 'true';
-    
-    if (playerName && autoload) {
-      console.log('Adding window load event for autoloading');
-      
-      // Add a one-time event listener for when everything is loaded
-      const handleLoad = () => {
-        setTimeout(() => {
-          // Try to find and click the GO button
-          const goButton = document.getElementById('go-button');
-          if (goButton && !goButton.disabled) {
-            console.log('Auto-clicking GO button from window load event');
-            goButton.click();
-          }
-        }, 1000); // Longer delay to ensure everything is ready
-      };
-      
-      window.addEventListener('load', handleLoad, { once: true });
-      
-      // Cleanup
-      return () => {
-        window.removeEventListener('load', handleLoad);
-      };
-    }
-  }, []);
-
   useEffect(() => {
     const fetchInitialData = async () => {
       try {
-        const [playersRes, venuesRes] = await Promise.all([
-          fetch(`${config.API_URL}/players`),
-          fetch(`${config.API_URL}/venues`)
-        ]);
-        const playersList = await playersRes.json();
-        setPlayers(playersList);
+        const venuesRes = await fetch(`${config.API_URL}/venues`);
         setVenues(['All Venues', ...await venuesRes.json()]);
         
-        console.log('Players loaded:', playersList);
         console.log('URL parameters:', { 
           name: getQueryParam('name'), 
           autoload: getQueryParam('autoload'),
@@ -128,18 +93,37 @@ const BowlerProfile = () => {
           setSelectedVenue(venueFromURL);
         }
         
-        if (playerNameFromURL && playersList.includes(playerNameFromURL)) {
-          console.log('Setting player from URL:', playerNameFromURL);
-          setSelectedPlayer(playerNameFromURL);
-          
-          // Auto-trigger data fetch if autoload parameter is true
-          if (autoload) {
-            setTimeout(() => {
-              setShouldFetch(true);
-            }, 500); // Small delay to ensure state is updated
+        if (playerNameFromURL) {
+          try {
+            const response = await fetch(
+              `${config.API_URL}/search/player/${encodeURIComponent(playerNameFromURL)}`
+            );
+            if (response.ok) {
+              const playerData = await response.json();
+              if (playerData?.found) {
+                const resolvedPlayer = {
+                  name: playerData.player_name,
+                  display_name: playerData.display_name || playerData.player_name,
+                };
+                console.log('Setting player from URL:', resolvedPlayer);
+                setSelectedPlayer(resolvedPlayer);
+                setPlayerSearchInput(resolvedPlayer.display_name);
+                setPlayerOptions((prev) => {
+                  if (prev.some((option) => option.name === resolvedPlayer.name)) {
+                    return prev;
+                  }
+                  return [resolvedPlayer, ...prev];
+                });
+                if (autoload) {
+                  setShouldFetch(true);
+                }
+              }
+            } else {
+              console.warn('Player name in URL not found:', playerNameFromURL);
+            }
+          } catch (resolveError) {
+            console.error('Error resolving player name:', resolveError);
           }
-        } else if (playerNameFromURL) {
-          console.warn('Player name in URL not found in player list:', playerNameFromURL);
         }
         
         setInitialLoadComplete(true);
@@ -152,30 +136,15 @@ const BowlerProfile = () => {
     fetchInitialData();
   }, []);
 
-  // Function to programmatically click the GO button when needed
-  useEffect(() => {
-    if (initialLoadComplete && selectedPlayer && getQueryParam('autoload') === 'true' && !stats && !loading && !shouldFetch) {
-      // Find and click the GO button after a small delay to ensure DOM is ready
-      const timer = setTimeout(() => {
-        const goButton = document.getElementById('go-button');
-        if (goButton) {
-          goButton.click();
-          console.log('Auto-clicking GO button');
-        }
-      }, 500);
-      
-      return () => clearTimeout(timer);
-    }
-  }, [initialLoadComplete, selectedPlayer, stats, loading, shouldFetch]);
-
   // Update URL when user changes filters
   useEffect(() => {
     if (!initialLoadComplete) return; // Skip on initial load
     
     const searchParams = new URLSearchParams();
     
-    if (selectedPlayer) {
-      searchParams.set('name', selectedPlayer);
+    const selectedPlayerName = typeof selectedPlayer === 'string' ? selectedPlayer : selectedPlayer?.name;
+    if (selectedPlayerName) {
+      searchParams.set('name', selectedPlayerName);
     }
     
     if (selectedVenue !== 'All Venues') {
@@ -200,14 +169,19 @@ const BowlerProfile = () => {
   }, [selectedPlayer, selectedVenue, dateRange, stats, initialLoadComplete, navigate]);
 
   const handleFetch = () => {
-    if (!selectedPlayer) return;
-    console.log('Manually triggered fetch for player:', selectedPlayer);
+    const selectedPlayerName = typeof selectedPlayer === 'string' ? selectedPlayer : selectedPlayer?.name;
+    if (!selectedPlayerName) return;
+    console.log('Manually triggered fetch for player:', selectedPlayerName);
     setShouldFetch(true);
   };
 
   const handleFilterChange = (key, value) => {
     if (key === 'player') {
       setSelectedPlayer(value);
+      if (value) {
+        const label = typeof value === 'string' ? value : (value.display_name || value.name);
+        setPlayerSearchInput(label);
+      }
       return;
     }
 
@@ -228,6 +202,12 @@ const BowlerProfile = () => {
 
   const handleApplyFilters = (nextValues, nextCompetitionFilters) => {
     setSelectedPlayer(nextValues.player);
+    if (nextValues.player) {
+      const label = typeof nextValues.player === 'string'
+        ? nextValues.player
+        : (nextValues.player.display_name || nextValues.player.name);
+      setPlayerSearchInput(label);
+    }
     setSelectedVenue(nextValues.venue);
     setDateRange({ start: nextValues.startDate, end: nextValues.endDate });
     setCompetitionFilters(nextCompetitionFilters);
@@ -250,8 +230,22 @@ const BowlerProfile = () => {
   }, [selectedVenue, dateRange, competitionFilters]);
 
   const filterConfig = useMemo(
-    () => buildBowlerProfileFilters({ players, venues }),
-    [players, venues]
+    () => buildBowlerProfileFilters({
+      players: playerOptions,
+      venues,
+      playerSearch: {
+        inputValue: playerSearchInput,
+        onInputChange: (_, nextInput, reason) => {
+          setPlayerSearchInput(nextInput);
+          if (reason === 'input') {
+            setSelectedPlayer(null);
+          }
+        },
+        loading: playerSearchLoading,
+        filterOptions: (options) => options,
+      },
+    }),
+    [playerOptions, playerSearchInput, playerSearchLoading, venues]
   );
 
   const filterValues = useMemo(
@@ -263,6 +257,53 @@ const BowlerProfile = () => {
     }),
     [selectedPlayer, dateRange, selectedVenue]
   );
+
+  const selectedPlayerName = useMemo(() => {
+    if (!selectedPlayer) return null;
+    return typeof selectedPlayer === 'string' ? selectedPlayer : selectedPlayer.name;
+  }, [selectedPlayer]);
+
+  const selectedPlayerLabel = useMemo(() => {
+    if (!selectedPlayer) return null;
+    return typeof selectedPlayer === 'string' ? selectedPlayer : (selectedPlayer.display_name || selectedPlayer.name);
+  }, [selectedPlayer]);
+
+  const searchDebounceRef = useRef(null);
+
+  useEffect(() => {
+    if (searchDebounceRef.current) {
+      clearTimeout(searchDebounceRef.current);
+    }
+
+    if (!playerSearchInput || playerSearchInput.trim().length < 2) {
+      setPlayerOptions([]);
+      setPlayerSearchLoading(false);
+      return;
+    }
+
+    searchDebounceRef.current = setTimeout(async () => {
+      setPlayerSearchLoading(true);
+      try {
+        const response = await fetch(
+          `${config.API_URL}/search/suggestions?q=${encodeURIComponent(playerSearchInput.trim())}&limit=10`
+        );
+        const data = await response.json();
+        const players = (data.suggestions || []).filter((item) => item.type === 'player');
+        setPlayerOptions(players);
+      } catch (searchError) {
+        console.error('Error fetching player suggestions:', searchError);
+        setPlayerOptions([]);
+      } finally {
+        setPlayerSearchLoading(false);
+      }
+    }, 250);
+
+    return () => {
+      if (searchDebounceRef.current) {
+        clearTimeout(searchDebounceRef.current);
+      }
+    };
+  }, [playerSearchInput]);
 
   const mobileFilterButton = (
     <Button
@@ -308,9 +349,10 @@ const BowlerProfile = () => {
   useEffect(() => {
     // Fetch bowling stats when shouldFetch is triggered
     const fetchBowlingStats = async () => {
-      if (!shouldFetch || !selectedPlayer) return;
+      if (!shouldFetch || !selectedPlayerName) return;
+      setShouldFetch(false);
       
-      console.log('Fetching bowling stats for player:', selectedPlayer);
+      console.log('Fetching bowling stats for player:', selectedPlayerName);
       setLoading(true);
       const params = new URLSearchParams();
       
@@ -327,8 +369,8 @@ const BowlerProfile = () => {
       try {
         // Fetch both bowling stats endpoints in parallel
         const [statsResponse, ballStatsResponse] = await Promise.all([
-          fetch(`${config.API_URL}/player/${encodeURIComponent(selectedPlayer)}/bowling_stats?${params}`),
-          fetch(`${config.API_URL}/player/${encodeURIComponent(selectedPlayer)}/bowling_ball_stats?${params}`)
+          fetch(`${config.API_URL}/player/${encodeURIComponent(selectedPlayerName)}/bowling_stats?${params}`),
+          fetch(`${config.API_URL}/player/${encodeURIComponent(selectedPlayerName)}/bowling_ball_stats?${params}`)
         ]);
     
         const [statsData, ballStatsData] = await Promise.all([
@@ -348,12 +390,11 @@ const BowlerProfile = () => {
         setError('Failed to load player bowling statistics');
       } finally {
         setLoading(false);
-        setShouldFetch(false);
       }
     };
 
     fetchBowlingStats();
-  }, [shouldFetch, selectedPlayer, dateRange, selectedVenue, competitionFilters]);
+  }, [shouldFetch, selectedPlayerName, dateRange, selectedVenue, competitionFilters]);
 
   return (
     <Container maxWidth="xl">
@@ -366,7 +407,7 @@ const BowlerProfile = () => {
 
         {isMobile && stats && (
           <MobileStickyHeader
-            title={selectedPlayer || 'Bowler Profile'}
+            title={selectedPlayerLabel || 'Bowler Profile'}
             action={mobileFilterButton}
             enableCollapse
           />
@@ -442,7 +483,7 @@ const BowlerProfile = () => {
                   <BowlingCareerStatsCards stats={stats} isMobile={isMobile} />
 
                   <PlayerDNASummary
-                    playerName={selectedPlayer}
+                    playerName={selectedPlayerName}
                     playerType="bowler"
                     startDate={dateRange.start}
                     endDate={dateRange.end}
@@ -455,13 +496,13 @@ const BowlerProfile = () => {
                   />
 
                   <ContextualQueryPrompts
-                    queries={getBowlerContextualQueries(selectedPlayer, {
+                    queries={getBowlerContextualQueries(selectedPlayerName, {
                       startDate: dateRange.start,
                       endDate: dateRange.end,
                       leagues: competitionFilters.leagues,
                       venue: selectedVenue !== 'All Venues' ? selectedVenue : null,
                     })}
-                    title={`🔍 Explore ${selectedPlayer.split(' ').pop()}'s Bowling Data`}
+                    title={`🔍 Explore ${(selectedPlayerLabel || 'Bowler').split(' ').pop()}'s Bowling Data`}
                     isMobile={isMobile}
                   />
                 </Section>
@@ -513,7 +554,7 @@ const BowlerProfile = () => {
                 >
                   <VisualizationCard isMobile={isMobile} ariaLabel="Wagon wheel showing where bowler was hit">
                     <BowlerWagonWheel
-                      playerName={selectedPlayer}
+                      playerName={selectedPlayerName}
                       startDate={dateRange.start}
                       endDate={dateRange.end}
                       venue={selectedVenue !== 'All Venues' ? selectedVenue : null}
@@ -526,7 +567,7 @@ const BowlerProfile = () => {
                   </VisualizationCard>
                   <VisualizationCard isMobile={isMobile} ariaLabel="Pitch map distribution for bowler">
                     <BowlerPitchMap
-                      playerName={selectedPlayer}
+                      playerName={selectedPlayerName}
                       startDate={dateRange.start}
                       endDate={dateRange.end}
                       venue={selectedVenue !== 'All Venues' ? selectedVenue : null}

--- a/src/components/CompetitionFilter.jsx
+++ b/src/components/CompetitionFilter.jsx
@@ -81,7 +81,13 @@ const CompetitionFilter = ({ onFilterChange, isMobile, value }) => {
         setIncludeInternational(resolvedFilters.international);
         setTopTeams(resolvedFilters.topTeams);
 
-        if (!value?.leagues?.length) {
+        const leaguesEqual = Array.isArray(value?.leagues)
+            && value.leagues.length === resolvedFilters.leagues.length
+            && value.leagues.every((league) => resolvedFilters.leagues.includes(league));
+        const internationalEqual = value?.international === resolvedFilters.international;
+        const topTeamsEqual = value?.topTeams === resolvedFilters.topTeams;
+
+        if (!leaguesEqual || !internationalEqual || !topTeamsEqual) {
             onFilterChange(resolvedFilters);
         }
     }, [leagues, value, onFilterChange]);

--- a/src/components/PlayerProfile.jsx
+++ b/src/components/PlayerProfile.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useMemo } from 'react';
+import React, { useState, useEffect, useMemo, useRef } from 'react';
 import {
   Container,
   Box,
@@ -48,7 +48,9 @@ const PlayerProfile = () => {
   const [selectedPlayer, setSelectedPlayer] = useState(null);
   const [dateRange, setDateRange] = useState({ start: DEFAULT_START_DATE, end: TODAY });
   const [selectedVenue, setSelectedVenue] = useState("All Venues");
-  const [players, setPlayers] = useState([]);
+  const [playerOptions, setPlayerOptions] = useState([]);
+  const [playerSearchInput, setPlayerSearchInput] = useState('');
+  const [playerSearchLoading, setPlayerSearchLoading] = useState(false);
   const [venues, setVenues] = useState([]);
   const [competitionFilters, setCompetitionFilters] = useState({
     leagues: [],
@@ -63,49 +65,12 @@ const PlayerProfile = () => {
   const [dnaFetchTrigger, setDnaFetchTrigger] = useState(0);
   const [filterDrawerOpen, setFilterDrawerOpen] = useState(false);
 
-  // Add a direct event listener to trigger analysis on page load if needed
-  useEffect(() => {
-    // This function will run once when component mounts
-    const urlParams = new URLSearchParams(window.location.search);
-    const playerName = urlParams.get('name');
-    const autoload = urlParams.get('autoload') === 'true';
-    
-    if (playerName && autoload) {
-      console.log('Adding window load event for autoloading');
-      
-      // Add a one-time event listener for when everything is loaded
-      const handleLoad = () => {
-        setTimeout(() => {
-          // Try to find and click the GO button
-          const goButton = document.getElementById('go-button');
-          if (goButton && !goButton.disabled) {
-            console.log('Auto-clicking GO button from window load event');
-            goButton.click();
-          }
-        }, 1000); // Longer delay to ensure everything is ready
-      };
-      
-      window.addEventListener('load', handleLoad, { once: true });
-      
-      // Cleanup
-      return () => {
-        window.removeEventListener('load', handleLoad);
-      };
-    }
-  }, []);
-
   useEffect(() => {
     const fetchInitialData = async () => {
       try {
-        const [playersRes, venuesRes] = await Promise.all([
-          fetch(`${config.API_URL}/players`),
-          fetch(`${config.API_URL}/venues`)
-        ]);
-        const playersList = await playersRes.json();
-        setPlayers(playersList);
+        const venuesRes = await fetch(`${config.API_URL}/venues`);
         setVenues(['All Venues', ...await venuesRes.json()]);
         
-        console.log('Players loaded:', playersList);
         console.log('URL parameters:', { 
           name: getQueryParam('name'), 
           autoload: getQueryParam('autoload'),
@@ -114,6 +79,7 @@ const PlayerProfile = () => {
         
         // Get player name and other parameters from URL if present
         const playerNameFromURL = getQueryParam('name');
+        const autoload = getQueryParam('autoload') === 'true';
         const startDateFromURL = getQueryParam('start_date');
         const endDateFromURL = getQueryParam('end_date');
         const venueFromURL = getQueryParam('venue');
@@ -133,15 +99,37 @@ const PlayerProfile = () => {
           setSelectedVenue(venueFromURL);
         }
         
-        if (playerNameFromURL && playersList.includes(playerNameFromURL)) {
-          console.log('Setting player from URL:', playerNameFromURL);
-          setSelectedPlayer(playerNameFromURL);
-
-          setTimeout(() => {
-            setShouldFetch(true);
-          }, 300);
-        } else if (playerNameFromURL) {
-          console.warn('Player name in URL not found in player list:', playerNameFromURL);
+        if (playerNameFromURL) {
+          try {
+            const response = await fetch(
+              `${config.API_URL}/search/player/${encodeURIComponent(playerNameFromURL)}`
+            );
+            if (response.ok) {
+              const playerData = await response.json();
+              if (playerData?.found) {
+                const resolvedPlayer = {
+                  name: playerData.player_name,
+                  display_name: playerData.display_name || playerData.player_name,
+                };
+                console.log('Setting player from URL:', resolvedPlayer);
+                setSelectedPlayer(resolvedPlayer);
+                setPlayerSearchInput(resolvedPlayer.display_name);
+                setPlayerOptions((prev) => {
+                  if (prev.some((option) => option.name === resolvedPlayer.name)) {
+                    return prev;
+                  }
+                  return [resolvedPlayer, ...prev];
+                });
+                if (autoload) {
+                  setShouldFetch(true);
+                }
+              }
+            } else {
+              console.warn('Player name in URL not found:', playerNameFromURL);
+            }
+          } catch (resolveError) {
+            console.error('Error resolving player name:', resolveError);
+          }
         }
         
         setInitialLoadComplete(true);
@@ -154,30 +142,15 @@ const PlayerProfile = () => {
     fetchInitialData();
   }, []);
 
-  // Function to programmatically click the GO button when needed
-  useEffect(() => {
-    if (initialLoadComplete && selectedPlayer && getQueryParam('autoload') === 'true' && !stats && !loading && !shouldFetch) {
-      // Find and click the GO button after a small delay to ensure DOM is ready
-      const timer = setTimeout(() => {
-        const goButton = document.getElementById('go-button');
-        if (goButton) {
-          goButton.click();
-          console.log('Auto-clicking GO button');
-        }
-      }, 500);
-      
-      return () => clearTimeout(timer);
-    }
-  }, [initialLoadComplete, selectedPlayer, stats, loading, shouldFetch]);
-
   // Update URL when user changes filters
   useEffect(() => {
     if (!initialLoadComplete) return; // Skip on initial load
     
     const searchParams = new URLSearchParams();
     
-    if (selectedPlayer) {
-      searchParams.set('name', selectedPlayer);
+    const selectedPlayerName = typeof selectedPlayer === 'string' ? selectedPlayer : selectedPlayer?.name;
+    if (selectedPlayerName) {
+      searchParams.set('name', selectedPlayerName);
     }
     
     if (selectedVenue !== 'All Venues') {
@@ -202,14 +175,19 @@ const PlayerProfile = () => {
   }, [selectedPlayer, selectedVenue, dateRange, stats, initialLoadComplete]);
 
   const handleFetch = () => {
-    if (!selectedPlayer) return;
-    console.log('Manually triggered fetch for player:', selectedPlayer);
+    const selectedPlayerName = typeof selectedPlayer === 'string' ? selectedPlayer : selectedPlayer?.name;
+    if (!selectedPlayerName) return;
+    console.log('Manually triggered fetch for player:', selectedPlayerName);
     setShouldFetch(true);
   };
 
   const handleFilterChange = (key, value) => {
     if (key === 'player') {
       setSelectedPlayer(value);
+      if (value) {
+        const label = typeof value === 'string' ? value : (value.display_name || value.name);
+        setPlayerSearchInput(label);
+      }
       return;
     }
 
@@ -230,6 +208,12 @@ const PlayerProfile = () => {
 
   const handleApplyFilters = (nextValues, nextCompetitionFilters) => {
     setSelectedPlayer(nextValues.player);
+    if (nextValues.player) {
+      const label = typeof nextValues.player === 'string'
+        ? nextValues.player
+        : (nextValues.player.display_name || nextValues.player.name);
+      setPlayerSearchInput(label);
+    }
     setSelectedVenue(nextValues.venue);
     setDateRange({ start: nextValues.startDate, end: nextValues.endDate });
     setCompetitionFilters(nextCompetitionFilters);
@@ -250,8 +234,22 @@ const PlayerProfile = () => {
   }, [selectedVenue, dateRange, competitionFilters]);
 
   const filterConfig = useMemo(
-    () => buildPlayerProfileFilters({ players, venues }),
-    [players, venues]
+    () => buildPlayerProfileFilters({
+      players: playerOptions,
+      venues,
+      playerSearch: {
+        inputValue: playerSearchInput,
+        onInputChange: (_, nextInput, reason) => {
+          setPlayerSearchInput(nextInput);
+          if (reason === 'input') {
+            setSelectedPlayer(null);
+          }
+        },
+        loading: playerSearchLoading,
+        filterOptions: (options) => options,
+      },
+    }),
+    [playerOptions, playerSearchInput, playerSearchLoading, venues]
   );
 
   const filterValues = useMemo(
@@ -264,12 +262,60 @@ const PlayerProfile = () => {
     [selectedPlayer, dateRange, selectedVenue]
   );
 
+  const selectedPlayerName = useMemo(() => {
+    if (!selectedPlayer) return null;
+    return typeof selectedPlayer === 'string' ? selectedPlayer : selectedPlayer.name;
+  }, [selectedPlayer]);
+
+  const selectedPlayerLabel = useMemo(() => {
+    if (!selectedPlayer) return null;
+    return typeof selectedPlayer === 'string' ? selectedPlayer : (selectedPlayer.display_name || selectedPlayer.name);
+  }, [selectedPlayer]);
+
+  const searchDebounceRef = useRef(null);
+
+  useEffect(() => {
+    if (searchDebounceRef.current) {
+      clearTimeout(searchDebounceRef.current);
+    }
+
+    if (!playerSearchInput || playerSearchInput.trim().length < 2) {
+      setPlayerOptions([]);
+      setPlayerSearchLoading(false);
+      return;
+    }
+
+    searchDebounceRef.current = setTimeout(async () => {
+      setPlayerSearchLoading(true);
+      try {
+        const response = await fetch(
+          `${config.API_URL}/search/suggestions?q=${encodeURIComponent(playerSearchInput.trim())}&limit=10`
+        );
+        const data = await response.json();
+        const players = (data.suggestions || []).filter((item) => item.type === 'player');
+        setPlayerOptions(players);
+      } catch (searchError) {
+        console.error('Error fetching player suggestions:', searchError);
+        setPlayerOptions([]);
+      } finally {
+        setPlayerSearchLoading(false);
+      }
+    }, 250);
+
+    return () => {
+      if (searchDebounceRef.current) {
+        clearTimeout(searchDebounceRef.current);
+      }
+    };
+  }, [playerSearchInput]);
+
   useEffect(() => {
     // Inside fetchPlayerStats function in useEffect
     const fetchPlayerStats = async () => {
-        if (!shouldFetch || !selectedPlayer) return;
+        if (!shouldFetch || !selectedPlayerName) return;
+        setShouldFetch(false);
 
-        console.log('Fetching stats for player:', selectedPlayer);
+        console.log('Fetching stats for player:', selectedPlayerName);
         setLoading(true);
         const params = new URLSearchParams();
         
@@ -286,8 +332,8 @@ const PlayerProfile = () => {
         try {
           // Fetch both stats in parallel
           const [statsResponse, ballStatsResponse] = await Promise.all([
-            fetch(`${config.API_URL}/player/${encodeURIComponent(selectedPlayer)}/stats?${params}`),
-            fetch(`${config.API_URL}/player/${encodeURIComponent(selectedPlayer)}/ball_stats?${params}`)
+            fetch(`${config.API_URL}/player/${encodeURIComponent(selectedPlayerName)}/stats?${params}`),
+            fetch(`${config.API_URL}/player/${encodeURIComponent(selectedPlayerName)}/ball_stats?${params}`)
           ]);
       
           const [statsData, ballStatsData] = await Promise.all([
@@ -306,12 +352,11 @@ const PlayerProfile = () => {
           setError('Failed to load player statistics');
         } finally {
           setLoading(false);
-          setShouldFetch(false);
         }
     };
 
     fetchPlayerStats();
-  }, [shouldFetch, selectedPlayer, dateRange, selectedVenue, competitionFilters]);
+  }, [shouldFetch, selectedPlayerName, dateRange, selectedVenue, competitionFilters]);
 
   const mobileFilterButton = (
     <Button
@@ -365,7 +410,7 @@ const PlayerProfile = () => {
 
         {isMobile && stats && (
           <MobileStickyHeader
-            title={selectedPlayer || 'Player Profile'}
+            title={selectedPlayerLabel || 'Player Profile'}
             action={mobileFilterButton}
             enableCollapse
           />
@@ -441,7 +486,7 @@ const PlayerProfile = () => {
                   <CareerStatsCards stats={stats} isMobile={isMobile} />
 
                   <PlayerDNASummary
-                    playerName={selectedPlayer}
+                    playerName={selectedPlayerName}
                     startDate={dateRange.start}
                     endDate={dateRange.end}
                     leagues={competitionFilters.leagues}
@@ -469,7 +514,7 @@ const PlayerProfile = () => {
                 >
                   <VisualizationCard isMobile={isMobile} ariaLabel="Wagon wheel shot map">
                     <WagonWheel
-                      playerName={selectedPlayer}
+                      playerName={selectedPlayerName}
                       startDate={dateRange.start}
                       endDate={dateRange.end}
                       venue={selectedVenue !== 'All Venues' ? selectedVenue : null}
@@ -482,7 +527,7 @@ const PlayerProfile = () => {
                   </VisualizationCard>
                   <VisualizationCard isMobile={isMobile} ariaLabel="Pitch map distribution">
                     <PlayerPitchMap
-                      playerName={selectedPlayer}
+                      playerName={selectedPlayerName}
                       startDate={dateRange.start}
                       endDate={dateRange.end}
                       venue={selectedVenue !== 'All Venues' ? selectedVenue : null}
@@ -511,7 +556,7 @@ const PlayerProfile = () => {
                   </VisualizationCard>
                   <VisualizationCard isMobile={isMobile} ariaLabel="Strike rate progression chart">
                     <StrikeRateProgression
-                      selectedPlayer={selectedPlayer}
+                      selectedPlayer={selectedPlayerName}
                       dateRange={dateRange}
                       selectedVenue={selectedVenue}
                       competitionFilters={competitionFilters}
@@ -542,15 +587,15 @@ const PlayerProfile = () => {
 
                 {/* Contextual Query Prompts */}
                 <ContextualQueryPrompts
-                  queries={getBatterContextualQueries(selectedPlayer, {
-                    startDate: dateRange.start,
-                    endDate: dateRange.end,
-                    leagues: competitionFilters.leagues,
-                    venue: selectedVenue !== 'All Venues' ? selectedVenue : null,
-                  })}
-                  title={`🔍 Explore ${selectedPlayer.split(' ').pop()}'s Data`}
-                  isMobile={isMobile}
-                />
+                    queries={getBatterContextualQueries(selectedPlayerName, {
+                      startDate: dateRange.start,
+                      endDate: dateRange.end,
+                      leagues: competitionFilters.leagues,
+                      venue: selectedVenue !== 'All Venues' ? selectedVenue : null,
+                    })}
+                    title={`🔍 Explore ${(selectedPlayerLabel || 'Player').split(' ').pop()}'s Data`}
+                    isMobile={isMobile}
+                  />
               </Box>
             )}
           </Box>

--- a/src/components/bowlerProfile/filterConfig.js
+++ b/src/components/bowlerProfile/filterConfig.js
@@ -1,7 +1,7 @@
 export const DEFAULT_START_DATE = '2020-01-01';
 export const TODAY = new Date().toISOString().split('T')[0];
 
-export const buildBowlerProfileFilters = ({ players, venues }) => [
+export const buildBowlerProfileFilters = ({ players, venues, playerSearch = {} }) => [
   {
     key: 'player',
     label: 'Select Player',
@@ -9,6 +9,7 @@ export const buildBowlerProfileFilters = ({ players, venues }) => [
     options: players,
     defaultValue: null,
     required: true,
+    ...playerSearch,
   },
   {
     key: 'startDate',

--- a/src/components/playerProfile/FilterBar.jsx
+++ b/src/components/playerProfile/FilterBar.jsx
@@ -34,26 +34,33 @@ const FilterBar = ({
 
   const renderFilterField = (filter) => {
     if (filter.type === 'autocomplete') {
+      const getOptionLabel = filter.getOptionLabel || ((option) => {
+        if (typeof option === 'string') {
+          return option;
+        }
+        return option?.display_name || option?.name || '';
+      });
+      const isOptionEqualToValue = filter.isOptionEqualToValue || ((option, value) => {
+        if (!value) return false;
+        if (typeof option === 'string' || typeof value === 'string') {
+          return option === value;
+        }
+        return option?.name === value?.name;
+      });
       return (
         <Autocomplete
           key={filter.key}
           value={values[filter.key]}
           onChange={(_, newValue) => onChange(filter.key, newValue)}
           options={filter.options}
+          inputValue={filter.inputValue}
+          onInputChange={filter.onInputChange}
+          loading={filter.loading}
+          filterOptions={filter.filterOptions}
           fullWidth
           size="small"
-          getOptionLabel={(option) => {
-            if (typeof option === 'string') {
-              return option;
-            }
-            return option || '';
-          }}
-          isOptionEqualToValue={(option, value) => {
-            if (typeof value === 'string') {
-              return option === value;
-            }
-            return option === value;
-          }}
+          getOptionLabel={getOptionLabel}
+          isOptionEqualToValue={isOptionEqualToValue}
           renderInput={(params) => (
             <TextField
               {...params}

--- a/src/components/playerProfile/FilterSheet.jsx
+++ b/src/components/playerProfile/FilterSheet.jsx
@@ -54,26 +54,33 @@ const FilterSheet = ({
 
   const renderFilterField = (filter) => {
     if (filter.type === 'autocomplete') {
+      const getOptionLabel = filter.getOptionLabel || ((option) => {
+        if (typeof option === 'string') {
+          return option;
+        }
+        return option?.display_name || option?.name || '';
+      });
+      const isOptionEqualToValue = filter.isOptionEqualToValue || ((option, value) => {
+        if (!value) return false;
+        if (typeof option === 'string' || typeof value === 'string') {
+          return option === value;
+        }
+        return option?.name === value?.name;
+      });
       return (
         <Autocomplete
           key={filter.key}
           value={draftValues[filter.key]}
           onChange={(_, newValue) => handleChange(filter.key, newValue)}
           options={filter.options}
+          inputValue={filter.inputValue}
+          onInputChange={filter.onInputChange}
+          loading={filter.loading}
+          filterOptions={filter.filterOptions}
           fullWidth
           size="medium"
-          getOptionLabel={(option) => {
-            if (typeof option === 'string') {
-              return option;
-            }
-            return option || '';
-          }}
-          isOptionEqualToValue={(option, value) => {
-            if (typeof value === 'string') {
-              return option === value;
-            }
-            return option === value;
-          }}
+          getOptionLabel={getOptionLabel}
+          isOptionEqualToValue={isOptionEqualToValue}
           renderInput={(params) => (
             <TextField
               {...params}

--- a/src/components/playerProfile/filterConfig.js
+++ b/src/components/playerProfile/filterConfig.js
@@ -1,7 +1,7 @@
 export const DEFAULT_START_DATE = '2020-01-01';
 export const TODAY = new Date().toISOString().split('T')[0];
 
-export const buildPlayerProfileFilters = ({ players, venues }) => [
+export const buildPlayerProfileFilters = ({ players, venues, playerSearch = {} }) => [
   {
     key: 'player',
     label: 'Select Player',
@@ -9,6 +9,7 @@ export const buildPlayerProfileFilters = ({ players, venues }) => [
     options: players,
     defaultValue: null,
     required: true,
+    ...playerSearch,
   },
   {
     key: 'startDate',


### PR DESCRIPTION
### Motivation
- Fix a backend error where player bowling stats failed when no leagues were passed, by treating empty league/international selections as "all competitions".
- Prevent redundant filter emissions that could trigger repeated fetch loops from initialization or unchanged filter values.
- Make player selection and autoload behavior more robust by resolving aliases and separating backend `name` identifiers from UI display labels.
- Improve player autocomplete UX by making suggestion fetching async, debounced, and plumbable into the filter components.

### Description
- Update backend match filtering in `main.py` for `player/{player_name}/stats`, `ball_stats`, and `bowling_stats` to include `OR (NOT :has_leagues AND NOT :include_international)` and set `params["leagues"] = []` when no leagues are provided so empty selections are treated as all competitions.
- Add equality checks in `CompetitionFilter` so `onFilterChange` is only emitted when the resolved filters actually differ from the incoming `value`.
- Refactor `PlayerProfile` and `BowlerProfile` to use resolved player objects with `{ name, display_name }`, introduce `selectedPlayerName` for backend calls and `selectedPlayerLabel` for UI, resolve `name` from URL via `GET /search/player/{name}`, and clear `shouldFetch` at fetch start so autoload runs only once.
- Wire async, debounced suggestions into the filter plumbing by extending `buildPlayerProfileFilters`/`buildBowlerProfileFilters` to accept player search props and updating `FilterBar`/`FilterSheet` to accept `inputValue`, `onInputChange`, `loading`, `filterOptions`, and robust `getOptionLabel`/`isOptionEqualToValue` logic.

### Testing
- No automated tests were run against these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69638b82ea18832c89752a7b96bb5360)