### PR TITLE
Add 'Guess the Innings' MVP (backend endpoint + frontend game UI)

### DIFF
--- a/main.py
+++ b/main.py
@@ -35,6 +35,7 @@ from routers.player_summary import router as player_summary_router
 from routers.wrapped import router as wrapped_router
 from routers.search import router as search_router
 from routers.visualizations import router as visualizations_router
+from routers.games import router as games_router
 from services.delivery_data_service import get_venue_match_stats, get_match_scores, get_venue_phase_stats
 from services.bowler_types import BOWLER_CATEGORY_SQL
 import math
@@ -168,6 +169,7 @@ app.include_router(player_summary_router)
 app.include_router(wrapped_router)
 app.include_router(search_router)
 app.include_router(visualizations_router)
+app.include_router(games_router)
 
 # Add CORS middleware
 app.add_middleware(

--- a/routers/games.py
+++ b/routers/games.py
@@ -1,0 +1,185 @@
+"""
+Games Router - endpoints for interactive game modes.
+"""
+
+from datetime import date
+from typing import List, Optional
+
+from fastapi import APIRouter, Depends, HTTPException, Query
+from sqlalchemy.orm import Session
+from sqlalchemy.sql import text
+
+from database import get_session
+from services.visualizations import expand_league_abbreviations
+
+router = APIRouter(prefix="/games", tags=["games"])
+
+
+@router.get("/guess-innings")
+def get_guess_innings(
+    leagues: List[str] = Query(default=["IPL"]),
+    competitions: List[str] = Query(default=[]),
+    start_date: Optional[date] = Query(default=date(2015, 1, 1)),
+    end_date: Optional[date] = Query(default=None),
+    pool_limit: int = Query(default=1000, ge=1, le=5000),
+    min_runs: int = Query(default=0, ge=0),
+    min_balls: int = Query(default=0, ge=0),
+    min_strike_rate: float = Query(default=0, ge=0),
+    include_answer: bool = Query(default=False),
+    db: Session = Depends(get_session),
+):
+    """
+    Fetch a random innings (with wagon wheel data) for the Guess the Innings game.
+
+    The innings pool is restricted to the top N by runs, balls faced, or strike rate,
+    and is filtered by competition and date range.
+    """
+
+    if end_date and start_date and end_date < start_date:
+        raise HTTPException(status_code=400, detail="end_date cannot be earlier than start_date")
+
+    expanded_leagues = expand_league_abbreviations(leagues) if leagues else []
+    competition_filter = competitions or expanded_leagues
+    if not competition_filter:
+        raise HTTPException(status_code=400, detail="At least one competition or league must be provided")
+
+    innings_query = text(
+        """
+        WITH innings AS (
+            SELECT
+                dd.p_match AS match_id,
+                dd.innings,
+                dd.bat AS batter,
+                dd.ground AS venue,
+                dd.competition AS competition,
+                dd.match_date AS match_date,
+                COUNT(*) AS balls,
+                SUM(dd.score) AS runs,
+                SUM(CASE WHEN dd.wagon_x IS NOT NULL AND dd.wagon_y IS NOT NULL THEN 1 ELSE 0 END) AS wagon_balls
+            FROM delivery_details dd
+            WHERE dd.bat IS NOT NULL
+              AND dd.competition = ANY(:competitions)
+              AND dd.match_date >= :start_date
+              AND (:end_date IS NULL OR dd.match_date <= :end_date)
+            GROUP BY dd.p_match, dd.innings, dd.bat, dd.ground, dd.competition, dd.match_date
+        ),
+        ranked AS (
+            SELECT
+                *,
+                CASE WHEN balls > 0 THEN (runs::float * 100.0 / balls) ELSE 0 END AS strike_rate,
+                DENSE_RANK() OVER (ORDER BY runs DESC) AS rank_runs,
+                DENSE_RANK() OVER (ORDER BY balls DESC) AS rank_balls,
+                DENSE_RANK() OVER (ORDER BY (CASE WHEN balls > 0 THEN (runs::float * 100.0 / balls) ELSE 0 END) DESC) AS rank_sr
+            FROM innings
+            WHERE wagon_balls > 0
+              AND runs >= :min_runs
+              AND balls >= :min_balls
+        )
+        SELECT
+            match_id,
+            innings,
+            batter,
+            venue,
+            competition,
+            match_date,
+            balls,
+            runs,
+            strike_rate
+        FROM ranked
+        WHERE (rank_runs <= :pool_limit OR rank_balls <= :pool_limit OR rank_sr <= :pool_limit)
+          AND strike_rate >= :min_strike_rate
+        ORDER BY RANDOM()
+        LIMIT 1
+        """
+    )
+
+    result = db.execute(
+        innings_query,
+        {
+            "competitions": competition_filter,
+            "start_date": start_date,
+            "end_date": end_date,
+            "pool_limit": pool_limit,
+            "min_runs": min_runs,
+            "min_balls": min_balls,
+            "min_strike_rate": min_strike_rate,
+        },
+    ).fetchone()
+
+    if not result:
+        raise HTTPException(status_code=404, detail="No innings found for the specified filters")
+
+    deliveries_query = text(
+        """
+        SELECT
+            dd.over,
+            dd.ball,
+            dd.score AS runs,
+            dd.shot,
+            dd.bowl AS bowler,
+            dd.wagon_x,
+            dd.wagon_y,
+            dd.wagon_zone
+        FROM delivery_details dd
+        WHERE dd.p_match = :match_id
+          AND dd.innings = :innings
+          AND dd.bat = :batter
+          AND dd.wagon_x IS NOT NULL
+          AND dd.wagon_y IS NOT NULL
+        ORDER BY dd.over, dd.ball
+        """
+    )
+
+    deliveries = db.execute(
+        deliveries_query,
+        {
+            "match_id": result.match_id,
+            "innings": result.innings,
+            "batter": result.batter,
+        },
+    ).fetchall()
+
+    if not deliveries:
+        raise HTTPException(status_code=404, detail="No wagon wheel deliveries found for this innings")
+
+    payload = {
+        "innings": {
+            "match_id": result.match_id,
+            "innings": result.innings,
+            "venue": result.venue,
+            "competition": result.competition,
+            "match_date": str(result.match_date) if result.match_date else None,
+            "runs": int(result.runs) if result.runs is not None else 0,
+            "balls": int(result.balls) if result.balls is not None else 0,
+            "strike_rate": float(result.strike_rate) if result.strike_rate is not None else 0.0,
+        },
+        "deliveries": [
+            {
+                "over": row.over,
+                "ball": row.ball,
+                "runs": row.runs,
+                "shot": row.shot,
+                "bowler": row.bowler,
+                "wagon_x": row.wagon_x,
+                "wagon_y": row.wagon_y,
+                "wagon_zone": row.wagon_zone,
+            }
+            for row in deliveries
+        ],
+        "filters": {
+            "competitions": competition_filter,
+            "start_date": str(start_date) if start_date else None,
+            "end_date": str(end_date) if end_date else None,
+            "pool_limit": pool_limit,
+            "min_runs": min_runs,
+            "min_balls": min_balls,
+            "min_strike_rate": min_strike_rate,
+        },
+    }
+
+    if include_answer:
+        payload["answer"] = {
+            "batter": result.batter,
+        }
+
+    return payload

--- a/src/App.js
+++ b/src/App.js
@@ -37,6 +37,7 @@ import TeamProfile from './components/TeamProfile';
 import TeamComparison from './components/TeamComparison';
 import WrappedPage from './components/wrapped/WrappedPage';
 import { GoogleSearchLanding, SearchBar } from './components/search';
+import GuessInningsGame from './components/games/GuessInningsGame';
 import axios from 'axios';
 
 import config from './config';
@@ -118,10 +119,11 @@ const AppContent = () => {
     path === '/matchups' ? 6 : 
     path === '/query' ? 7 : 
     path === '/team' ? 8 : 
-    path === '/team-comparison' ? 9 :
-    path === '/wrapped/2025' ? 10 : 0
-      );
-            }
+    path === '/team-comparison' ? 9 : 
+    path === '/games/guess-innings' ? 10 :
+    path === '/wrapped/2025' ? 11 : 0
+    );
+    }
   };
 
   useEffect(() => {
@@ -140,7 +142,8 @@ const AppContent = () => {
         path === '/query' ? 7 : 
         path === '/team' ? 8 : 
         path === '/team-comparison' ? 9 :
-        path === '/wrapped/2025' || path.startsWith('/wrapped') ? 10 : 0
+        path === '/games/guess-innings' ? 10 :
+        path === '/wrapped/2025' || path.startsWith('/wrapped') ? 11 : 0
       );
     }
   }, [location]);
@@ -420,7 +423,8 @@ const AppContent = () => {
            currentTab === 7 ? 'Query Builder' : 
            currentTab === 8 ? 'Team Profile' : 
            currentTab === 9 ? 'Team Comparison' :
-           currentTab === 10 ? '2025 Wrapped' : 'Home';
+           currentTab === 10 ? 'Guess the Innings' :
+           currentTab === 11 ? '2025 Wrapped' : 'Home';
   };
 
   return (
@@ -513,6 +517,9 @@ const AppContent = () => {
               </MenuItem>
               <MenuItem onClick={() => handleNavigate('/team-comparison')}>                Team Comparison
               </MenuItem>
+              <MenuItem onClick={() => handleNavigate('/games/guess-innings')}>
+                🎯 Guess the Innings
+              </MenuItem>
               <MenuItem onClick={() => handleNavigate('/wrapped/2025')} sx={{ color: '#1DB954', fontWeight: 600 }}>
                 🎁 2025 Wrapped
               </MenuItem>
@@ -549,6 +556,7 @@ const AppContent = () => {
               <Tab label="Query Builder" component={Link} to="/query" />
               <Tab label="Team Profile" component={Link} to="/team" />
               <Tab label="Team Comparison" component={Link} to="/team-comparison" />
+              <Tab label="🎯 Guess the Innings" component={Link} to="/games/guess-innings" />
               <Tab label="🎁 2025 Wrapped" component={Link} to="/wrapped/2025" sx={{ color: '#1DB954' }} />
             </Tabs>
             <IconButton
@@ -572,6 +580,7 @@ const AppContent = () => {
         <Route path="/query" element={<QueryBuilder isMobile={isMobile} />} />
         <Route path="/team" element={<TeamProfile isMobile={isMobile} />} />
         <Route path="/team-comparison" element={<TeamComparison />} />
+        <Route path="/games/guess-innings" element={<GuessInningsGame isMobile={isMobile} />} />
         <Route path="/wrapped/2025" element={<WrappedPage />} />
         <Route path="/search" element={<GoogleSearchLanding />} />
         <Route path="/venue" element={

--- a/src/components/games/GuessInningsGame.jsx
+++ b/src/components/games/GuessInningsGame.jsx
@@ -1,0 +1,335 @@
+/**
+ * Guess the Innings Game
+ *
+ * Fetches a random innings with wagon wheel data and animates shots chronologically.
+ */
+
+import React, { useEffect, useMemo, useRef, useState } from 'react';
+import {
+  Box,
+  Button,
+  Chip,
+  CircularProgress,
+  Divider,
+  Stack,
+  TextField,
+  Typography
+} from '@mui/material';
+import Card from '../ui/Card';
+import config from '../../config';
+import { colors as designColors } from '../../theme/designSystem';
+
+const DEFAULT_FILTERS = {
+  leagues: 'IPL',
+  competitions: '',
+  startDate: '2015-01-01',
+  endDate: '',
+  poolLimit: 1000,
+  minRuns: 0,
+  minBalls: 0,
+  minStrikeRate: 0,
+};
+
+const runColor = (runs) => {
+  if (runs === 6) return designColors.orange[500];
+  if (runs === 4) return designColors.green[500];
+  if (runs === 3) return designColors.blue[400];
+  if (runs === 2) return designColors.blue[300];
+  if (runs === 1) return designColors.blue[200];
+  return designColors.neutral[300];
+};
+
+const GuessInningsGame = ({ isMobile = false }) => {
+  const [filters, setFilters] = useState(DEFAULT_FILTERS);
+  const [data, setData] = useState(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState(null);
+  const [visibleCount, setVisibleCount] = useState(0);
+  const [isPlaying, setIsPlaying] = useState(false);
+  const [guess, setGuess] = useState('');
+  const [revealAnswer, setRevealAnswer] = useState(false);
+  const [containerSize, setContainerSize] = useState(360);
+  const chartContainerRef = useRef(null);
+  const playTimerRef = useRef(null);
+
+  useEffect(() => {
+    if (!chartContainerRef.current) return;
+    const resizeObserver = new ResizeObserver(entries => {
+      entries.forEach(entry => {
+        const nextWidth = Math.max(240, Math.floor(entry.contentRect.width));
+        setContainerSize(nextWidth);
+      });
+    });
+    resizeObserver.observe(chartContainerRef.current);
+    return () => resizeObserver.disconnect();
+  }, []);
+
+  useEffect(() => {
+    if (!isPlaying || !data) return;
+    playTimerRef.current = setInterval(() => {
+      setVisibleCount((prev) => {
+        if (!data?.deliveries) return prev;
+        if (prev >= data.deliveries.length) {
+          setIsPlaying(false);
+          return prev;
+        }
+        return prev + 1;
+      });
+    }, 350);
+    return () => clearInterval(playTimerRef.current);
+  }, [isPlaying, data]);
+
+  const deliveries = useMemo(() => data?.deliveries || [], [data]);
+  const visibleDeliveries = useMemo(() => deliveries.slice(0, visibleCount), [deliveries, visibleCount]);
+  const answer = data?.answer?.batter || '';
+  const normalizedGuess = guess.trim().toLowerCase();
+  const isCorrect = answer && normalizedGuess && answer.trim().toLowerCase() === normalizedGuess;
+
+  const resetPlayback = () => {
+    setVisibleCount(0);
+    setIsPlaying(false);
+  };
+
+  const fetchGame = async () => {
+    setLoading(true);
+    setError(null);
+    setRevealAnswer(false);
+    setGuess('');
+    setVisibleCount(0);
+    setIsPlaying(false);
+
+    const params = new URLSearchParams();
+    const leagues = filters.leagues.split(',').map(item => item.trim()).filter(Boolean);
+    leagues.forEach(league => params.append('leagues', league));
+    const competitions = filters.competitions.split(',').map(item => item.trim()).filter(Boolean);
+    competitions.forEach(competition => params.append('competitions', competition));
+    if (filters.startDate) params.append('start_date', filters.startDate);
+    if (filters.endDate) params.append('end_date', filters.endDate);
+    params.append('pool_limit', filters.poolLimit);
+    params.append('min_runs', filters.minRuns);
+    params.append('min_balls', filters.minBalls);
+    params.append('min_strike_rate', filters.minStrikeRate);
+    params.append('include_answer', 'true');
+
+    try {
+      const response = await fetch(`${config.API_URL}/games/guess-innings?${params.toString()}`);
+      if (!response.ok) {
+        throw new Error('Failed to fetch innings');
+      }
+      const payload = await response.json();
+      setData(payload);
+    } catch (err) {
+      setError(err.message);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const renderWagonWheel = () => {
+    if (!data) return null;
+    const width = Math.min(containerSize, isMobile ? 320 : 420);
+    const height = width;
+    const centerX = width / 2;
+    const centerY = height / 2;
+    const maxRadius = width * 0.4;
+    const batterRadius = width * 0.02;
+    const zoneLines = [];
+    for (let i = 0; i < 8; i++) {
+      const angle = (i * Math.PI / 4) - (Math.PI / 2);
+      const x2 = centerX + maxRadius * Math.cos(angle);
+      const y2 = centerY + maxRadius * Math.sin(angle);
+      zoneLines.push(
+        <line
+          key={`zone-${i}`}
+          x1={centerX}
+          y1={centerY}
+          x2={x2}
+          y2={y2}
+          stroke={designColors.neutral[200]}
+          strokeWidth="1"
+          strokeDasharray="4,4"
+        />
+      );
+    }
+
+    const deliveryDots = visibleDeliveries
+      .filter(d => d.wagon_x !== null && d.wagon_y !== null)
+      .map((delivery, index) => {
+        const scale = maxRadius / 150;
+        const x = centerX + (delivery.wagon_x - 150) * scale;
+        const y = centerY + (delivery.wagon_y - 150) * scale;
+        const isLatest = index === visibleDeliveries.length - 1;
+        return (
+          <circle
+            key={`delivery-${index}`}
+            cx={x}
+            cy={y}
+            r={isLatest ? 5 : 3.5}
+            fill={runColor(delivery.runs)}
+            stroke={isLatest ? designColors.neutral[900] : designColors.neutral[50]}
+            strokeWidth={isLatest ? 2 : 1}
+            opacity={isLatest ? 1 : 0.75}
+          />
+        );
+      });
+
+    return (
+      <svg width={width} height={height} viewBox={`0 0 ${width} ${height}`}>
+        <circle cx={centerX} cy={centerY} r={maxRadius} fill={designColors.neutral[50]} stroke={designColors.neutral[200]} />
+        {zoneLines}
+        <circle cx={centerX} cy={centerY} r={batterRadius} fill={designColors.neutral[800]} />
+        {deliveryDots}
+      </svg>
+    );
+  };
+
+  return (
+    <Box sx={{ my: 3 }}>
+      <Typography variant="h4" sx={{ mb: 2 }}>
+        Guess the Innings (MVP)
+      </Typography>
+      <Typography variant="body1" sx={{ mb: 3 }}>
+        Watch the wagon wheel animation and guess the batter. Filters are configurable for league and innings pool selection.
+      </Typography>
+
+      <Card sx={{ mb: 3 }}>
+        <Typography variant="h6" sx={{ mb: 2 }}>Game Filters</Typography>
+        <Stack direction={{ xs: 'column', md: 'row' }} spacing={2} sx={{ mb: 2 }}>
+          <TextField
+            label="Leagues (comma-separated)"
+            value={filters.leagues}
+            onChange={(event) => setFilters(prev => ({ ...prev, leagues: event.target.value }))}
+            fullWidth
+          />
+          <TextField
+            label="Competitions (override leagues)"
+            value={filters.competitions}
+            onChange={(event) => setFilters(prev => ({ ...prev, competitions: event.target.value }))}
+            fullWidth
+          />
+        </Stack>
+        <Stack direction={{ xs: 'column', md: 'row' }} spacing={2} sx={{ mb: 2 }}>
+          <TextField
+            label="Start Date"
+            type="date"
+            value={filters.startDate}
+            onChange={(event) => setFilters(prev => ({ ...prev, startDate: event.target.value }))}
+            InputLabelProps={{ shrink: true }}
+            fullWidth
+          />
+          <TextField
+            label="End Date"
+            type="date"
+            value={filters.endDate}
+            onChange={(event) => setFilters(prev => ({ ...prev, endDate: event.target.value }))}
+            InputLabelProps={{ shrink: true }}
+            fullWidth
+          />
+        </Stack>
+        <Stack direction={{ xs: 'column', md: 'row' }} spacing={2} sx={{ mb: 2 }}>
+          <TextField
+            label="Pool Limit (top N by runs/balls/SR)"
+            type="number"
+            value={filters.poolLimit}
+            onChange={(event) => setFilters(prev => ({ ...prev, poolLimit: Number(event.target.value) }))}
+            fullWidth
+          />
+          <TextField
+            label="Min Runs"
+            type="number"
+            value={filters.minRuns}
+            onChange={(event) => setFilters(prev => ({ ...prev, minRuns: Number(event.target.value) }))}
+            fullWidth
+          />
+          <TextField
+            label="Min Balls"
+            type="number"
+            value={filters.minBalls}
+            onChange={(event) => setFilters(prev => ({ ...prev, minBalls: Number(event.target.value) }))}
+            fullWidth
+          />
+          <TextField
+            label="Min Strike Rate"
+            type="number"
+            value={filters.minStrikeRate}
+            onChange={(event) => setFilters(prev => ({ ...prev, minStrikeRate: Number(event.target.value) }))}
+            fullWidth
+          />
+        </Stack>
+        <Button variant="contained" onClick={fetchGame} disabled={loading}>
+          {loading ? 'Loading...' : 'Start New Game'}
+        </Button>
+        {error && (
+          <Typography variant="body2" color="error" sx={{ mt: 2 }}>
+            {error}
+          </Typography>
+        )}
+      </Card>
+
+      {loading && (
+        <Box sx={{ display: 'flex', justifyContent: 'center', my: 4 }}>
+          <CircularProgress />
+        </Box>
+      )}
+
+      {data && !loading && (
+        <Card>
+          <Stack spacing={2}>
+            <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 1 }}>
+              <Chip label={`Balls shown: ${visibleCount}/${deliveries.length}`} />
+              <Chip label={`Runs: ${data.innings?.runs}`} />
+              <Chip label={`SR: ${data.innings?.strike_rate?.toFixed?.(1) ?? data.innings?.strike_rate}`} />
+              <Chip label={`Competition: ${data.innings?.competition}`} />
+              <Chip label={`Date: ${data.innings?.match_date}`} />
+              <Chip label={`Venue: ${data.innings?.venue}`} />
+            </Box>
+
+            <Divider />
+
+            <Box ref={chartContainerRef} sx={{ width: '100%', display: 'flex', justifyContent: 'center' }}>
+              {renderWagonWheel()}
+            </Box>
+
+            <Stack direction={{ xs: 'column', md: 'row' }} spacing={2} alignItems="center">
+              <Button variant="outlined" onClick={() => setIsPlaying((prev) => !prev)} disabled={visibleCount >= deliveries.length}>
+                {isPlaying ? 'Pause' : 'Play'}
+              </Button>
+              <Button variant="outlined" onClick={() => setVisibleCount((prev) => Math.min(prev + 1, deliveries.length))}>
+                Next Shot
+              </Button>
+              <Button variant="outlined" onClick={resetPlayback}>
+                Reset
+              </Button>
+            </Stack>
+
+            <Divider />
+
+            <Stack direction={{ xs: 'column', md: 'row' }} spacing={2} alignItems="center">
+              <TextField
+                label="Your Guess (Batter)"
+                value={guess}
+                onChange={(event) => setGuess(event.target.value)}
+                fullWidth
+              />
+              <Button variant="contained" onClick={() => setRevealAnswer(true)}>
+                Reveal Answer
+              </Button>
+            </Stack>
+            {guess && (
+              <Typography variant="body2" color={isCorrect ? 'success.main' : 'text.secondary'}>
+                {isCorrect ? 'Correct!' : 'Keep guessing...'}
+              </Typography>
+            )}
+            {revealAnswer && (
+              <Typography variant="body1">
+                Answer: <strong>{answer}</strong>
+              </Typography>
+            )}
+          </Stack>
+        </Card>
+      )}
+    </Box>
+  );
+};
+
+export default GuessInningsGame;


### PR DESCRIPTION
### Motivation
- Provide an MVP interactive game that shows wagon-wheel deliveries and asks the user to guess the batter. 
- Restrict the initial pool to innings that have wagon-wheel data (delivery_details), and default to IPL matches from 2015 onwards. 
- Allow configurable filters (league/competition, date range, top-N pool, min runs/balls/SR) so selection can be tuned later. 
- Keep the design future-proof to allow incorporating ODI and Test ball-by-ball data later. 

### Description
- Added a new backend router `routers/games.py` exposing `GET /games/guess-innings` which selects a random innings (top N by runs/balls/SR) with wagon-wheel deliveries and returns innings metadata, deliveries and applied filters. 
- Registered the games router in `main.py` via `app.include_router(games_router)`. 
- Implemented the frontend MVP `GuessInningsGame` in `src/components/games/GuessInningsGame.jsx` with filter controls, wagon-wheel SVG rendering, chronological playback, and answer reveal. 
- Wired the new UI into navigation and routes by importing the component and adding a menu/tab and `Route` in `src/App.js`, and fixed a `useMemo` dependency for `deliveries`. 

### Testing
- Started the frontend dev server with `npm start`, which launched successfully though the project shows existing ESLint warnings. 
- Used an automated Playwright script to load `/games/guess-innings` and capture a screenshot (`artifacts/guess-innings-mvp.png`), which completed successfully. 
- No automated backend integration tests were executed in this rollout, and no unit tests were added. 
- Changes committed: one commit containing the new router and frontend files (`Add guess the innings MVP`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6963b0e7a6e8832cb9c3421070b020fc)